### PR TITLE
Added support for django custom user with no 'username' field

### DIFF
--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -39,7 +39,8 @@ class UserSocialAuth(models.Model, DjangoUserMixin):
 
     @classmethod
     def username_max_length(cls):
-        field = UserSocialAuth.user_model()._meta.get_field('username')
+        username_field = getattr(UserSocialAuth.user_model(), 'USERNAME_FIELD', 'username')
+        field = UserSocialAuth.user_model()._meta.get_field(username_field)
         return field.max_length
 
     @classmethod

--- a/social/storage/django_orm.py
+++ b/social/storage/django_orm.py
@@ -49,11 +49,13 @@ class DjangoUserMixin(UserMixin):
         Return True/False if a User instance exists with the given arguments.
         Arguments are directly passed to filter() manager method.
         """
-        return cls.user_model().objects.filter(username=username).count() > 0
+        username_field = getattr(cls.user_model(), 'USERNAME_FIELD', 'username')
+        return cls.user_model().objects.filter(**{username_field:username}).count() > 0
 
     @classmethod
     def get_username(cls, user):
-        return getattr(user, 'username', None)
+        username_field = getattr(cls.user_model(), 'USERNAME_FIELD', 'username')
+        return getattr(user, username_field, None)
 
     @classmethod
     def create_user(cls, username, email=None):


### PR DESCRIPTION
Hi,

I come accross this issue today while working with a custom user model on django 1.5. Code from psa was failing when there was no field named "username". I think this pull request can solve this issue in a backwards compatible way.

MongoEngine: I've never work with it, don't know if the same changes should be included.
DSA: If you want me to, tomorrow I write the solution also for django-social-auth.

Thanks for your work!
