### PR TITLE
Bug fix of FacebookAppOAuth2

### DIFF
--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -105,6 +105,7 @@ class FacebookAppOAuth2(FacebookOAuth2):
 
     def auth_complete(self, *args, **kwargs):
         access_token = None
+        response = {}
 
         if 'signed_request' in self.data:
             key, secret = self.get_key_and_secret()


### PR DESCRIPTION
In FacebookAppOAuth2.auth_complete, you make the call to do_auth with the parameter expires instead the expected parameter response, and it falls.
