### PR TITLE
Added a default to response in FacebookOAuth.do_auth

### DIFF
--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -77,7 +77,9 @@ class FacebookOAuth2(BaseOAuth2):
             'client_secret': client_secret
         }
 
-    def do_auth(self, access_token, response={}, *args, **kwargs):
+    def do_auth(self, access_token, response=None, *args, **kwargs):
+        response = response or {}
+
         data = self.user_data(access_token)
 
         if not isinstance(data, dict):


### PR DESCRIPTION
The response default can be a dict because, inside the method, you are using this similar as a dict, but in future cases that you need the Response object this will fail.
