### PR TITLE
Modify positional and keyword arguments to fix a multiple keyword argume...

### DIFF
--- a/social/apps/webpy_app/utils.py
+++ b/social/apps/webpy_app/utils.py
@@ -36,7 +36,7 @@ def strategy(redirect_uri=None):
             self.strategy = load_strategy(request=web.ctx, backend=backend,
                                           redirect_uri=uri, *args, **kwargs)
             if backend:
-                return func(self, backend=backend, *args, **kwargs)
+                return func(self, backend, *args, **kwargs)
             else:
                 return func(self, *args, **kwargs)
         return wrapper

--- a/social/backends/base.py
+++ b/social/backends/base.py
@@ -21,7 +21,7 @@ class BaseAuth(object):
     supports_inactive_user = False  # Django auth
     ID_KEY = None
 
-    def __init__(self, strategy=None, redirect_uri=None, *args, **kwargs):
+    def __init__(self, strategy=None, backend=None, storage=None, request=None, redirect_uri=None):
         self.strategy = strategy
         self.redirect_uri = redirect_uri
         self.data = {}

--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -31,18 +31,21 @@ class BaseStrategy(object):
                     'ABCDEFGHIJKLMNOPQRSTUVWXYZ' \
                     '0123456789'
 
-    def __init__(self, backend=None, storage=None, request=None, tpl=None,
+    def __init__(self, backend=None, storage=None, request=None,
                  backends=None, *args, **kwargs):
-        tpl = tpl or BaseTemplateStrategy
+        tpl = kwargs.pop('tpl', BaseTemplateStrategy)
         if not isinstance(tpl, BaseTemplateStrategy):
             tpl = tpl(self)
         self.tpl = tpl
         self.request = request
         self.storage = storage
         self.backends = backends
+        redirect_uri = kwargs.pop('redirect_uri', None)
         if backend:
             self.backend_name = backend.name
-            self.backend = backend(strategy=self, *args, **kwargs)
+            self.backend = backend(strategy=self, backend=backend,
+                                   storage=storage, request=request,
+                                   redirect_uri=redirect_uri)
         else:
             self.backend_name = None
             self.backend = backend

--- a/social/strategies/utils.py
+++ b/social/strategies/utils.py
@@ -2,8 +2,9 @@ from social.utils import module_member
 from social.backends.utils import get_backend
 
 
-def get_strategy(backends, strategy, storage, request=None, backend=None,
-                 *args, **kwargs):
+def get_strategy(backends, strategy, storage, *args, **kwargs):
+    backend = kwargs.pop('backend', None)
+    request = kwargs.pop('request', None)
     if backend:
         Backend = get_backend(backends, backend)
         if not Backend:
@@ -12,5 +13,4 @@ def get_strategy(backends, strategy, storage, request=None, backend=None,
         Backend = None
     Strategy = module_member(strategy)
     Storage = module_member(storage)
-    return Strategy(Backend, Storage, request, backends=backends,
-                    *args, **kwargs)
+    return Strategy(Backend, Storage, request, backends, *args, **kwargs)


### PR DESCRIPTION
While using web.py and trying to disassociate accounts, I kept running into an error:

``` python
 File "../../social/apps/webpy_app/utils.py", line 37, in wrapper
    redirect_uri=uri, *args, **kwargs)
  File "../../social/apps/webpy_app/utils.py", line 26, in load_strategy
    return get_strategy(backends, strategy, storage, *args, **kwargs)
TypeError: get_strategy() got multiple values for keyword argument 'request'
```

This pull request fixed the problem, and passes all nosetests as well.
