### PR TITLE
SQLAlchemy fixes

### DIFF
--- a/social/storage/sqlalchemy_orm.py
+++ b/social/storage/sqlalchemy_orm.py
@@ -146,7 +146,7 @@ class SQLAlchemyAssociationMixin(SQLAlchemyMixin, AssociationMixin):
 
     @classmethod
     def remove(cls, ids_to_delete):
-        cls._query().filter(cls.id.in_(ids_to_delete)).delete()
+        cls._query().filter(cls.id.in_(ids_to_delete)).delete(synchronize_session='fetch')
 
 
 class BaseSQLAlchemyStorage(BaseStorage):


### PR DESCRIPTION
This pull request fixes two bugs I encountered when using the SQLAlchemy orm.
1. The disconnect method doesn't commit the session after removing the association, preventing the association from being really deleted.
2. Calling the **remove** method of a `SQLAlchemyAssociationMixin` raise an `InvalidRequestError: Could not evaluate current criteria in Python. Specify 'fetch' or False for the synchronize_session parameter.`
