### PR TITLE
Fixed auth redirect URL for BaseOauth2 always redirecting wrong

### DIFF
--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -262,7 +262,10 @@ class BaseOAuth2(OAuthAuth):
         params = self.auth_params(state)
         params.update(self.get_scope_argument())
         params.update(self.auth_extra_arguments())
-        return self.AUTHORIZATION_URL + '?' + unquote(urlencode(params))
+        if self.REDIRECT_STATE: # redirect_uri is not strictly enforced. Encode the redirect state into the redirect_uri to prevent forgery.
+            return self.AUTHORIZATION_URL + '?' + urlencode(params)
+        else: # redirect_uri matching is strictly enforced, so match the providers value exactly.
+            return self.AUTHORIZATION_URL + '?' + unquote(urlencode(params))
 
     def validate_state(self):
         """Validate state value. Raises exception on error, returns state


### PR DESCRIPTION
OAuth2 providers expect the url to be an unquoted value.
