### PR TITLE
Fixes #45 -- AttributeError while resolving the user model in Django

### DIFF
--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -1,4 +1,6 @@
 """Django ORM models for Social Auth"""
+import six
+
 from django.db import models
 from django.conf import settings
 from django.db.utils import IntegrityError
@@ -52,7 +54,11 @@ class UserSocialAuth(models.Model, DjangoUserMixin):
 
     @classmethod
     def user_model(cls):
-        return UserSocialAuth._meta.get_field('user').rel.to
+        user_model = UserSocialAuth._meta.get_field('user').rel.to
+        if isinstance(user_model, six.string_types):
+            app_label, model_name = user_model.split('.')
+            return models.get_model(app_label, model_name)
+        return user_model
 
 
 class Nonce(models.Model, DjangoNonceMixin):


### PR DESCRIPTION
Under some conditions `UserSocialAuth._meta.get_field('user').rel.to` does not return a Model class but a string of the form `'<app_label>.<model_name>'`. This results in an AttributeError in the Django admin.py which ultimately triggers an error in Django's RegexURLResolver. This is fixed by properly resolving the user model and return a class rather than a string.

``` ipdb
ipdb> /home/markus/Coding/python-social-auth/social/apps/django_app/default/admin.py(5)<module>()
      4 
----> 5 from django.contrib import admin
      6 from social.apps.django_app.default.models import UserSocialAuth, Nonce, \

ipdb> n
> /home/markus/Coding/python-social-auth/social/apps/django_app/default/admin.py(6)<module>()
      5 from django.contrib import admin
----> 6 from social.apps.django_app.default.models import UserSocialAuth, Nonce, \
      7                                                   Association

ipdb> 
> /home/markus/Coding/python-social-auth/social/apps/django_app/default/admin.py(10)<module>()
      9 
---> 10 _User = UserSocialAuth.user_model()
     11 
> /home/markus/Coding/python-social-auth/social/apps/django_app/default/models.py(59)user_model()
     58 
---> 59     @classmethod
     60     def user_model(cls):

ipdb> n
> /home/markus/Coding/python-social-auth/social/apps/django_app/default/models.py(61)user_model()
     60     def user_model(cls):
---> 61         return UserSocialAuth._meta.get_field('user').rel.to
     62 

ipdb> UserSocialAuth._meta
<Options for UserSocialAuth>
ipdb> UserSocialAuth._meta.get_field('user')
<django.db.models.fields.related.ForeignKey: user>
ipdb> UserSocialAuth._meta.get_field('user').rel
<django.db.models.fields.related.ManyToOneRel object at 0x7f8d29848fd0>
ipdb> UserSocialAuth._meta.get_field('user').rel.to
'auth.BakeryUser'
```
