### PR TITLE
Make partial_pipeline JSON serializable for django 1.6

### DIFF
--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -4,6 +4,7 @@ from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import authenticate
 from django.template import TemplateDoesNotExist, RequestContext, loader
+from django.utils.datastructures import MergeDict
 from django.utils.translation import get_language
 
 from social.strategies.base import BaseStrategy, BaseTemplateStrategy
@@ -104,6 +105,8 @@ class DjangoStrategy(BaseStrategy):
                 'pk': val.pk,
                 'ctype': ContentType.objects.get_for_model(val).pk
             }
+        if isinstance(val, MergeDict):
+            val = dict(val)
         return val
 
     def from_session_value(self, val):


### PR DESCRIPTION
With django 1.6 the default session serializer is changed from `django.contrib.sessions.serializers.PickleSerializer` to `django.contrib.sessions.serializers.JSONSerializer` this causes an exception when partial pipelines is used. 

The error that is thrown is:

``` python
TypeError: MergeDict(<QueryDict: {u'password1': [u'test'], u'password2': [u'test'], u'email': [test@example.com']}>, <QueryDict: {}>) is not JSON serializable
```

This happens when the `response` key of the partial of saved to the session with a `MergeDict` as the value. I've added a conversion from `MergeDict` to `dict` in `DjangoStrategy`.
