### PR TITLE
Refresh the docs on http://psa.matiasaguirre.net/docs/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ Documents
 =========
 
 Project homepage is available at http://psa.matiasaguirre.net/ and documents at
-http://psa.matiasaguirre.net/docs/.
+python-social-auth.readthedocs.org/.
 
 
 Installation


### PR DESCRIPTION
The docs on the website are not up to date.

For ex: At the bottom of http://psa.matiasaguirre.net/docs/configuration/django.html an interim fix is mentioned for an issue with Django 1.6 but this is no longer needed. The docs in the repo were also updated in bb2f08127005091544a69208e9adf0aeccce9479 to reflect the same, but the website wasn't.
