### PR TITLE
Replaced explicit db_table definitions with app_label definitions.

### DIFF
--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -36,7 +36,7 @@ class UserSocialAuth(models.Model, DjangoUserMixin):
     class Meta:
         """Meta data"""
         unique_together = ('provider', 'uid')
-        db_table = 'social_auth_usersocialauth'
+        app_label = 'social_auth'
 
     @classmethod
     def get_social_auth(cls, provider, uid):
@@ -68,7 +68,7 @@ class Nonce(models.Model, DjangoNonceMixin):
     salt = models.CharField(max_length=40)
 
     class Meta:
-        db_table = 'social_auth_nonce'
+        app_label = 'social_auth'
 
 
 class Association(models.Model, DjangoAssociationMixin):
@@ -81,7 +81,7 @@ class Association(models.Model, DjangoAssociationMixin):
     assoc_type = models.CharField(max_length=64)
 
     class Meta:
-        db_table = 'social_auth_association'
+        app_label = 'social_auth'
 
 
 class Code(models.Model, DjangoCodeMixin):
@@ -90,7 +90,7 @@ class Code(models.Model, DjangoCodeMixin):
     verified = models.BooleanField(default=False)
 
     class Meta:
-        db_table = 'social_auth_code'
+        app_label = 'social_auth'
         unique_together = ('email', 'code')
 
 


### PR DESCRIPTION
This allows for better-named South migrations; rather than the models coming under the "default" app_label, they come under the "social_auth" app_label.
