### PR TITLE
Missing trailing slash on complete url

### DIFF
--- a/docs/backends/persona.rst
+++ b/docs/backends/persona.rst
@@ -12,7 +12,7 @@ POST to `python-social-auth`_::
     <script src="https://login.persona.org/include.js" type="text/javascript"></script>
 
     <!-- Define a form to send the POST data -->
-    <form method="post" action="/complete/persona">
+    <form method="post" action="/complete/persona/">
         <input type="hidden" name="assertion" value="" />
         <a rel="nofollow" id="persona" href="#">Mozilla Persona</a>
     </form>


### PR DESCRIPTION
Hi,

If the django config attribute APPEND_SLASH is set to false, then the example does not work.

Adding the trailing slash solve it.
