### PR TITLE
Removed non-ascii character from author string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 setup(name='python-social-auth',
       version=version,
-      author='Matías Aguirre',
+      author='Matias Aguirre',
       author_email='matiasaguirre@gmail.com',
       description='Python social authentication made simple.',
       license='BSD',


### PR DESCRIPTION
Trying to install python-social-auth on a system where the default encoding is NOT ascii or latin1, installation fails with UnicodeDecodeError.  

It seems that the PKG-INFO format requires that header values are in ASCII following RFC-822. (I'm not sure, but it seems that PKG-INFO is auto-generated from this setup.py).

My appologies to Matias.

C:\Python33\Scripts>python3 pip-3.3-script.py install python-social-auth
Downloading/unpacking python-social-auth
  Downloading python-social-auth-0.1.17.tar.gz (71kB): 71kB downloaded
  Running setup.py egg_info for package python-social-auth

Cleaning up...
Exception:
Traceback (most recent call last):
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\basecommand.py", line 134, in main
    status = self.run(options, args)
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\commands\install.py", line 236, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\req.py", line 1139, in prepare_files
    req_to_install.assert_source_matches_version()
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\req.py", line 394, in assert_source_matches_version
    version = self.installed_version
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\req.py", line 390, in installed_version
    return self.pkg_info()['version']
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\req.py", line 357, in pkg_info
    data = self.egg_info_data('PKG-INFO')
  File "C:\Python33\lib\site-packages\pip-1.4.1-py3.3.egg\pip\req.py", line 297, in egg_info_data
    data = fp.read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 184: illegal multibyte sequence
