### PR TITLE
python-requests version must be < 2.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ def long_description():
         return LONG_DESCRIPTION
 
 
-requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0']
+requires = ['requests>=1.1,<2.0', 'oauthlib>=0.3.8', 'six>=1.2.0']
+
 if PY3:
     requires += ['python3-openid>=3.0.1',
                  'requests-oauthlib>=0.3.0,<0.3.2']


### PR DESCRIPTION
python-requests 2.0 has many backwards-incompatible changes and is not currently compatible with python-social-auth.
