### PR TITLE
Updated pipeline example to include externalized auth.

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -52,6 +52,19 @@ ones would look like this::
         'social.pipeline.user.user_details'
     )
 
+Note that this assumes the user is already authenticated, and thus the ``user`` key 
+in the dict is populated. In cases where the authentication is purely external, a
+pipeline method must be provided that populates the ``user`` key. Example::
+
+
+    SOCIAL_AUTH_PIPELINE = (
+        'myapp.pipeline.load_user',
+        'social.pipeline.social_auth.social_user',
+        'social.pipeline.social_auth.associate_user',
+        'social.pipeline.social_auth.load_extra_data',
+        'social.pipeline.user.user_details',
+    )
+
 Each pipeline function will receive the following parameters:
     * Current strategy (which gives access to current store, backend and request)
     * User ID given by authentication provider


### PR DESCRIPTION
See http://stackoverflow.com/questions/20504515/associate-only-authentication-with-python-social-authentication-and-django
