### PR TITLE
GooglePlusAuth backend do not store 'access_token' on extra_data (psa v0.1.17)

### DIFF
--- a/social/backends/google.py
+++ b/social/backends/google.py
@@ -79,11 +79,9 @@ class GooglePlusAuth(BaseGoogleOAuth2API, BaseOAuth2):
         ('user_id', 'user_id'),
         ('refresh_token', 'refresh_token', True),
         ('expires_in', 'expires'),
-        ('access_type', 'access_type', True)
+        ('access_type', 'access_type', True),
+        ('code', 'code')
     ]
-
-    def extra_data(self, user, uid, response, details):
-        return {'code': response.get('code')}
 
     def auth_complete(self, *args, **kwargs):
         token = self.data.get('access_token')


### PR DESCRIPTION
(working with python-social-auth v0.1.17)

I'm working on a project with facebook, twitter and g+ backends and I have found an issue with g+.

GooglePlusAuth backend stores 'code' on extra_data, but as it is said on [1] this code is for only one-time use and should be exchanged for an access_token. I expect PSA to do this step.

I'm trying to figure out how to solve this issue but I'm a little bit confused about the oauth2 thing; I'll update this issue if I manage to solve it.

Thanks.

NOTE.- Related to this, when the user disconnect g+ there is an unexpected behaviour because 'access_token' is not found at [2] and tokens are not removed.

[1] https://developers.google.com/+/web/signin/server-side-flow#step_6_send_the_authorization_code_to_the_server

[2] https://github.com/omab/python-social-auth/blob/v0.1.17/social/pipeline/disconnect.py#L23
