### PR TITLE
updated live connection for better support

### DIFF
--- a/social/backends/live.py
+++ b/social/backends/live.py
@@ -24,11 +24,6 @@ class LiveOAuth2(BaseOAuth2):
         ('token_type', 'token_type'),
     ]
 
-    def extra_data(self, user, uid, response, details):
-        extra_data = super(LiveOAuth2, self).extra_data(user, uid, response, details)
-        extra_data['email'] = response.get('emails', {}).get('account')
-        return extra_data
-
     def get_user_details(self, response):
         """Return user details from Live Connect account"""
         return {'username': response.get('name'),


### PR DESCRIPTION
Windows live support had some fields wrong and others missing.

The most important one was the "reset_token" that now is "refresh_token", without it is not possible to refresh that connection, which is pretty bad. Also to be able to get the email you need to access a dictionary inside a dictionary so I fixed that by overriding the extra_data function.

Here is an example response from windows live:

```
{u'access_token': u'MYACCESSTOKEN',
 u'authentication_token': u'MYAUTHTOKEN',
 u'emails': {u'account': u'someemail@outlook.com',
         u'business': None,
         u'personal': None,
         u'preferred': u'someemail@outlook.com'},
 u'expires_in': 3600,
 u'first_name': u'Tomas',
 u'gender': None,
 u'id': u'9999999999999999',
 u'last_name': u'Henriquez',
 u'link': u'https://profile.live.com/',
 u'locale': u'en_US',
 u'name': u'Tomas Henriquez',
 u'refresh_token': u'MYREFRESHTOKEN',
 u'scope': u'wl.basic wl.emails wl.offline_access wl.imap',
 u'token_type': u'bearer',
 u'updated_time': u'2014-02-10T20:58:15+0000'}
```
