### PR TITLE
Fix bug trying to concatenate list to string #186

### DIFF
--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -38,8 +38,8 @@ class OAuthAuth(BaseAuth):
 
     def get_scope(self):
         """Return list with needed access scope"""
-        return (self.DEFAULT_SCOPE or []) + \
-               self.setting('SCOPE', [])
+        return (self.DEFAULT_SCOPE or '') + \
+               self.setting('SCOPE', '')
 
     def get_scope_argument(self):
         param = {}


### PR DESCRIPTION
```
def get_scope(self):
    """Return list with needed access scope"""
    return (self.DEFAULT_SCOPE or []) + \
           self.setting('SCOPE', [])
```

When the user has a 'SCOPE' set part after + is a string. That in turn
tries to do:

[] + ''

That isn't valid python and throws an error, this fixes that.
