### PR TITLE
Documentation update for django

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -6,6 +6,14 @@ from `django-social-auth`_. Here are some details on configuring this
 application on Django.
 
 
+Strategy
+--------
+
+Configure the strategy to be used::
+
+    SOCIAL_AUTH_STRATEGY = 'social.strategies.django_strategy.DjangoStrategy'
+
+
 Register the application
 ------------------------
 


### PR DESCRIPTION
It seems that, for django at least, it isn't mentioned in the docs that you have to set the SOCIAL_AUTH_STRATEGY setting ... here's a quick fix for django.
