### PR TITLE
Fixed Django < 1.4 support in context processors.

### DIFF
--- a/social/apps/django_app/context_processors.py
+++ b/social/apps/django_app/context_processors.py
@@ -5,7 +5,7 @@ try:
     from django.utils.functional import empty as _empty
     empty = _empty
 except ImportError:  # django < 1.4
-    empty = object()
+    empty = None
 
 
 from social.backends.utils import user_backends_data


### PR DESCRIPTION
Prior to Django commit [60cf3f2f842b6e56132b8880c70acc87bd753c](https://github.com/django/django/commit/60cf3f2f842b6e56132b8880c70acc87bd753c2e),
Django was using `None` as a sentinel value.

The existing code in place to support Django 1.3 would not actually work.

I would have added some tests with this pull request but couldn't figure out where to put them.

I couldn't find which versions of Django you're supporting either, but note that in 1.6, Django added `__getitem__` and `__setitem__` methods on `LazyObject` so if/when you drop support for older versions, you can use a plain `SimpleLazyObject` instead of your custom `LazyDict`.
