### PR TITLE
Added backend for Ubuntu (One).

### DIFF
--- a/social/backends/ubuntu.py
+++ b/social/backends/ubuntu.py
@@ -1,0 +1,16 @@
+"""
+Ubuntu One OpenId backend
+"""
+from social.backends.open_id import OpenIdAuth
+
+
+class UbuntuOpenId(OpenIdAuth):
+    name = 'ubuntu'
+    URL = 'https://login.ubuntu.com'
+
+    def get_user_id(self, details, response):
+        """
+        Return user unique id provided by service. For Ubuntu One
+        the nickname should be original.
+        """
+        return details['nickname']


### PR DESCRIPTION
This adds a backend for Ubuntu One.

I haven't yet added any tests, mainly because this is just sets the URL for the current OpenID backend.
