### PR TITLE
User model fields accessors clashes issue solved

### DIFF
--- a/examples/django_example/example/app/models.py
+++ b/examples/django_example/example/app/models.py
@@ -1,6 +1,6 @@
 # Define a custom User class to work with django-social-auth
-from django.contrib.auth.models import AbstractUser, UserManager
+from django.contrib.auth.models import AbstractUser
 
 
 class CustomUser(AbstractUser):
-    objects = UserManager()
+    pass

--- a/examples/django_example/example/settings.py
+++ b/examples/django_example/example/settings.py
@@ -193,6 +193,8 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+AUTH_USER_MODEL = 'app.CustomUser'
+
 LOGIN_URL = '/login/'
 LOGIN_REDIRECT_URL = '/done/'
 URL_PATH = ''


### PR DESCRIPTION
Running the provided Django example was impossible with Django 1.6, it gave the following error:

```
python manage.py syncdb
CommandError: One or more models did not validate:
app.customuser: Accessor for m2m field 'groups' clashes with related m2m field 'Group.user_set'. Add a related_name argument to the definition for 'groups'.
app.customuser: Accessor for m2m field 'user_permissions' clashes with related m2m field 'Permission.user_set'. Add a related_name argument to the definition for 'user_permissions'.
auth.user: Accessor for m2m field 'groups' clashes with related m2m field 'Group.user_set'. Add a related_name argument to the definition for 'groups'.
auth.user: Accessor for m2m field 'user_permissions' clashes with related m2m field 'Permission.user_set'. Add a related_name argument to the definition for 'user_permissions'.
```
