### PR TITLE
Using https as required by the API

### DIFF
--- a/social/backends/yahoo.py
+++ b/social/backends/yahoo.py
@@ -41,7 +41,7 @@ class YahooOAuth(BaseOAuth1):
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
-        url = 'http://social.yahooapis.com/v1/user/{0}/profile?format=json'
+        url = 'https://social.yahooapis.com/v1/user/{0}/profile?format=json'
         return self.get_json(
             url.format(self._get_guid(access_token)),
             auth=self.oauth_auth(access_token)
@@ -53,6 +53,6 @@ class YahooOAuth(BaseOAuth1):
             it's also returned during one of OAuth calls
         """
         return self.get_json(
-            'http://social.yahooapis.com/v1/me/guid?format=json',
+            'https://social.yahooapis.com/v1/me/guid?format=json',
             auth=self.oauth_auth(access_token)
         )['guid']['value']

--- a/social/tests/backends/test_yahoo.py
+++ b/social/tests/backends/test_yahoo.py
@@ -7,7 +7,7 @@ from social.tests.backends.oauth import OAuth1Test
 
 class YahooOAuth1Test(OAuth1Test):
     backend_path = 'social.backends.yahoo.YahooOAuth'
-    user_data_url = 'http://social.yahooapis.com/v1/user/a-guid/profile?' \
+    user_data_url = 'https://social.yahooapis.com/v1/user/a-guid/profile?' \
                     'format=json'
     expected_username = 'foobar'
     access_token_body = json.dumps({
@@ -21,7 +21,7 @@ class YahooOAuth1Test(OAuth1Test):
     })
     guid_body = json.dumps({
         'guid': {
-            'uri': 'http://social.yahooapis.com/v1/me/guid',
+            'uri': 'https://social.yahooapis.com/v1/me/guid',
             'value': 'a-guid'
         }
     })
@@ -37,7 +37,7 @@ class YahooOAuth1Test(OAuth1Test):
                 'height': 192
             },
             'created': '2013-03-18T04:15:08Z',
-            'uri': 'http://social.yahooapis.com/v1/user/a-guid/profile',
+            'uri': 'https://social.yahooapis.com/v1/user/a-guid/profile',
             'isConnected': False,
             'profileUrl': 'http://profile.yahoo.com/a-guid',
             'guid': 'a-guid',
@@ -48,7 +48,7 @@ class YahooOAuth1Test(OAuth1Test):
     def test_login(self):
         HTTPretty.register_uri(
             HTTPretty.GET,
-            'http://social.yahooapis.com/v1/me/guid?format=json',
+            'https://social.yahooapis.com/v1/me/guid?format=json',
             status=200,
             body=self.guid_body
         )


### PR DESCRIPTION
[Yahoo Contacts and Profile APIs move to HTTPS](http://yahoodevelopers.tumblr.com/post/75633763287/yahoo-contacts-and-profile-apis-move-to-https)
`Yahoo Mail connections are now encrypted with HTTPS by default. To support this move, we have also enabled HTTPS access to Yahoo Contacts and Profile APIs.`
Yahoo Social API Guide:
[Introspective GUID](https://developer.yahoo.com/social/rest_api_guide/introspective-guid-resource.html)
[Usercard Profile](https://developer.yahoo.com/social/rest_api_guide/usercard-resource.html)

see also [this thread](https://developer.yahoo.com/forum/OAuth-General-Discussion-YDN-SDKs/http-social-yahooapis-com-Will-be-right-back/1395509802423-89faffa2-1503-486d-bc29-6505719bd774)
