### PR TITLE
Replace references to python-oauth2 with references to requests-oauthlib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,8 +142,7 @@ Dependencies that **must** be met to use the application:
 
 - OpenId_ support depends on python-openid_
 
-- OAuth_ support depends on python-oauth2_ (despite the name, this is just for
-  OAuth1)
+- OAuth_ support depends on requests-oauthlib_
 
 - Several backends demand application registration on their corresponding
   sites and other dependencies like sqlalchemy_ on Flask and Webpy.
@@ -274,7 +273,7 @@ check `django-social-auth LICENSE`_ for details:
 .. _Webpy: https://github.com/omab/python-social-auth/tree/master/social/apps/webpy_app
 .. _Tornado: http://www.tornadoweb.org/
 .. _python-openid: http://pypi.python.org/pypi/python-openid/
-.. _python-oauth2: https://github.com/simplegeo/python-oauth2
+.. _requests-oauthlib: https://requests-oauthlib.readthedocs.org/
 .. _sqlalchemy: http://www.sqlalchemy.org/
 .. _pypi: http://pypi.python.org/pypi/python-social-auth/
 .. _OpenStreetMap: http://www.openstreetmap.org

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -8,8 +8,7 @@ Dependencies that **must** be meet to use the application:
 
 - OpenId_ support depends on python-openid_
 
-- OAuth_ support depends on python-oauth2_ (despite the name, this is just for
-  OAuth1)
+- OAuth_ support depends on requests-oauthlib_
 
 - Several backends demands application registration on their corresponding
   sites and other dependencies like sqlalchemy_ on Flask and Webpy.
@@ -45,5 +44,5 @@ Or::
 .. _pypi: http://pypi.python.org/pypi/python-social-auth/
 .. _github: https://github.com/omab/python-social-auth
 .. _python-openid: http://pypi.python.org/pypi/python-openid/
-.. _python-oauth2: https://github.com/simplegeo/python-oauth2
+.. _requests-oauthlib: https://requests-oauthlib.readthedocs.org/
 .. _sqlalchemy: http://www.sqlalchemy.org/


### PR DESCRIPTION
Since, as far as I can tell, there is no longer any reference to the `oauth2` package in the code.
