### PR TITLE
from http API to https API

### DIFF
--- a/social/backends/flickr.py
+++ b/social/backends/flickr.py
@@ -8,9 +8,9 @@ from social.backends.oauth import BaseOAuth1
 class FlickrOAuth(BaseOAuth1):
     """Flickr OAuth authentication backend"""
     name = 'flickr'
-    AUTHORIZATION_URL = 'http://www.flickr.com/services/oauth/authorize'
-    REQUEST_TOKEN_URL = 'http://www.flickr.com/services/oauth/request_token'
-    ACCESS_TOKEN_URL = 'http://www.flickr.com/services/oauth/access_token'
+    AUTHORIZATION_URL = 'https://www.flickr.com/services/oauth/authorize'
+    REQUEST_TOKEN_URL = 'https://www.flickr.com/services/oauth/request_token'
+    ACCESS_TOKEN_URL = 'https://www.flickr.com/services/oauth/access_token'
     EXTRA_DATA = [
         ('id', 'id'),
         ('username', 'username'),


### PR DESCRIPTION
Non-SSL API deprecated: 27 June 2014, 10:00 (PDT)
