### PR TITLE
avoid updating default settings

### DIFF
--- a/social/backends/base.py
+++ b/social/backends/base.py
@@ -185,7 +185,7 @@ class BaseAuth(object):
     def auth_extra_arguments(self):
         """Return extra arguments needed on auth process. The defaults can be
         overriden by GET parameters."""
-        extra_arguments = self.setting('AUTH_EXTRA_ARGUMENTS', {})
+        extra_arguments = self.setting('AUTH_EXTRA_ARGUMENTS', {}).copy()
         extra_arguments.update((key, self.data[key]) for key in extra_arguments
                                     if key in self.data)
         return extra_arguments


### PR DESCRIPTION
This will make sure if a non-default extra argument appears in one request, subsequent requests w/o this extra argument will still use the default value.
