### PR TITLE
Fixed Django 1.7 admin

### DIFF
--- a/social/apps/django_app/default/admin.py
+++ b/social/apps/django_app/default/admin.py
@@ -14,11 +14,7 @@ class UserSocialAuthOption(admin.ModelAdmin):
     raw_id_fields = ('user',)
     list_select_related = True
 
-    def __init__(self, *args, **kwargs):
-        self.search_fields = self.get_search_fields()
-        super(UserSocialAuthOption, self).__init__(*args, **kwargs)
-
-    def get_search_fields(self):
+    def get_search_fields(self, request):
         search_fields = getattr(
             settings, setting_name('ADMIN_USER_SEARCH_FIELDS'), None
         )


### PR DESCRIPTION
Django 1.7 includes a built in 'get_search_fields' admin method which requires the 'request' parameter: https://docs.djangoproject.com/en/1.7/ref/contrib/admin/#django.contrib.admin.ModelAdmin.get_search_fields
