### PR TITLE
Quote all params in auth_url except redirect_url

### DIFF
--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -4,7 +4,7 @@ from requests import HTTPError
 from requests_oauthlib import OAuth1
 from oauthlib.oauth1 import SIGNATURE_TYPE_AUTH_HEADER
 
-from social.p3 import urlencode, unquote
+from social.p3 import urlencode, unquote, quote_plus
 from social.utils import url_add_parameters, parse_qs
 from social.exceptions import AuthFailed, AuthCanceled, AuthUnknownError, \
                               AuthMissingParameter, AuthStateMissing, \
@@ -283,12 +283,16 @@ class BaseOAuth2(OAuthAuth):
         params = self.auth_params(state)
         params.update(self.get_scope_argument())
         params.update(self.auth_extra_arguments())
-        params = urlencode(params)
-        if not self.REDIRECT_STATE:
-            # redirect_uri matching is strictly enforced, so match the
-            # providers value exactly.
-            params = unquote(params)
-        return self.AUTHORIZATION_URL + '?' + params
+
+        urlencoded_params = []
+
+        for key, value in params.items():
+            # redirect_uri is strictly enforced if there is no redirect state
+            if key != 'redirect_uri' or self.REDIRECT_STATE:
+                value = quote_plus(value)
+            urlencoded_params.append('%s=%s' % (quote_plus(key), value))
+
+        return self.AUTHORIZATION_URL + '?' + '&'.join(urlencoded_params)
 
     def validate_state(self):
         """Validate state value. Raises exception on error, returns state

--- a/social/p3.py
+++ b/social/p3.py
@@ -3,7 +3,7 @@ import six
 
 if six.PY3:
     from urllib.parse import parse_qs, urlparse, urlunparse, quote, \
-                             urlsplit, urlencode, unquote
+                             urlsplit, urlencode, unquote, quote_plus
     from io import StringIO
 else:
     try:
@@ -11,5 +11,5 @@ else:
     except ImportError:  # fall back for Python 2.5
         from cgi import parse_qs
     from urlparse import urlparse, urlunparse, urlsplit
-    from urllib import urlencode, unquote, quote
+    from urllib import urlencode, unquote, quote, quote_plus
     from StringIO import StringIO


### PR DESCRIPTION
`client_id` may contain special characters which break the URL (e.g. `&` or `;`).

This seems to have introduced in https://github.com/omab/python-social-auth/commit/05dc5ae0b3f812a4c54904cb25ffd0c7f3653fd9. I'm not sure of the reason exactly why `redirect_uri` needs to be unescaped, but presumably the other parameters of auth_url can be escaped without any issues.