### PR TITLE
reddit sometimes responds with "429 Too Many Requests" seemingly randomly

### DIFF
--- a/social/backends/reddit.py
+++ b/social/backends/reddit.py
@@ -5,6 +5,7 @@ Reddit OAuth2 backend, docs at:
 import base64
 
 from social.backends.oauth import BaseOAuth2
+import sys
 
 
 class RedditOAuth2(BaseOAuth2):


### PR DESCRIPTION
http://stackoverflow.com/questions/13213048/urllib2-http-error-429 fixes the problem

Basically reddit rate-limits their API based on the User-Agent string. Instead of sticking with the default (urllib User-Agent) this pull request sets User-Agent to 'python-social-auth-' + _ _ version _ _ so requests shouldn't hit the rate limit without knowing it
