### PR TITLE
fix for AssertionError in pyramid

### DIFF
--- a/social/storage/sqlalchemy_orm.py
+++ b/social/storage/sqlalchemy_orm.py
@@ -83,7 +83,11 @@ class SQLAlchemyUserMixin(SQLAlchemyMixin, UserMixin):
     @classmethod
     def disconnect(cls, entry):
         cls._session().delete(entry)
-        cls._session().commit()
+        try:
+            cls._session().commit()
+        except AssertionError:
+            import transaction
+            transaction.commit()
 
     @classmethod
     def user_query(cls):


### PR DESCRIPTION
fix for "AssertionError: Transaction must be committed using the transaction manager"
sqlalchemy commits in Pyramid use the transaction manager
