### PR TITLE
Fixed #327 -- Changed access token method on backend.

### DIFF
--- a/social/backends/github.py
+++ b/social/backends/github.py
@@ -13,6 +13,7 @@ class GithubOAuth2(BaseOAuth2):
     name = 'github'
     AUTHORIZATION_URL = 'https://github.com/login/oauth/authorize'
     ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+    ACCESS_TOKEN_METHOD = 'POST'
     SCOPE_SEPARATOR = ','
     EXTRA_DATA = [
         ('id', 'id'),

--- a/social/tests/actions/actions.py
+++ b/social/tests/actions/actions.py
@@ -110,7 +110,7 @@ class BaseActionTest(unittest.TestCase):
         expect(response.url).to.equal(location_url)
         expect(response.text).to.equal('foobar')
 
-        HTTPretty.register_uri(HTTPretty.GET,
+        HTTPretty.register_uri(HTTPretty.POST,
                                uri=self.backend.ACCESS_TOKEN_URL,
                                status=200,
                                body=self.access_token_body or '',


### PR DESCRIPTION
Just as a reference: https://developer.github.com/v3/oauth/#github-redirects-back-to-your-site says that it should be a POST.
