### PR TITLE
numeric index for format

### DIFF
--- a/social/apps/django_app/views.py
+++ b/social/apps/django_app/views.py
@@ -31,7 +31,7 @@ def disconnect(request, backend, association_id=None):
 
 
 def _do_login(backend, user, social_user):
-    user.backend = '{}.{}'.format(backend.__module__,
+    user.backend = '{0}.{1}'.format(backend.__module__,
                                   backend.__class__.__name__)
     login(backend.strategy.request, user)
     if backend.setting('SESSION_EXPIRATION', True):


### PR DESCRIPTION
django_app   _do_login   function needs to use numeric index when formatting string to support Python 2.6
