### PR TITLE
changed default behavior of SESSION_EXPIRATION setting

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -259,11 +259,15 @@ Miscellaneous settings
     objects, such as ``email``. Set this to a list of fields you only want to
     set for newly created users and avoid updating on further logins.
 
-``SOCIAL_AUTH_SESSION_EXPIRATION = True``
-    Some providers return the time that the access token will live, the value is
-    stored in ``UserSocialAuth.extra_data`` under the key ``expires``. By default
-    the current user session is set to expire if this value is present, this
-    behavior can be disabled by setting.
+``SOCIAL_AUTH_SESSION_EXPIRATION = False``
+    By default, user session expiration time will be set by your web
+    framework (in Django, for example, it is set with
+    SOCIAL_AUTH_SESSION_EXPIRATION). Some providers return the time that the
+    access token will live, which is stored in ``UserSocialAuth.extra_data``
+    under the key ``expires``. Changing this setting to True will override your
+    web framework's session length setting and set user session lengths to
+    match the ``expires`` value from the auth provider.
+
 
 ``SOCIAL_AUTH_OPENID_PAPE_MAX_AUTH_AGE = <int value>``
     Enable `OpenID PAPE`_ extension support by defining this setting.

--- a/social/apps/django_app/views.py
+++ b/social/apps/django_app/views.py
@@ -34,8 +34,8 @@ def _do_login(backend, user, social_user):
     user.backend = '{0}.{1}'.format(backend.__module__,
                                   backend.__class__.__name__)
     login(backend.strategy.request, user)
-    if backend.setting('SESSION_EXPIRATION', True):
-        # Set session expiration date if present and not disabled
+    if backend.setting('SESSION_EXPIRATION', False):
+        # Set session expiration date if present and enabled
         # by setting. Use last social-auth instance for current
         # provider, users can associate several accounts with
         # a same provider.


### PR DESCRIPTION
I ran tests, and they failed, but I /think/ it's for unrelated reasons:

(venv)~/workspace/python-social-auth$ ./run_tox.sh 
GLOB sdist-make: /Users/pyrak/workspace/python-social-auth/setup.py
py26 create: /Users/pyrak/workspace/python-social-auth/.tox/py26
py26 installdeps: -r/Users/pyrak/workspace/python-social-auth/social/tests/requirements.txt
py26 inst: /Users/pyrak/workspace/python-social-auth/.tox/dist/python-social-auth-0.2.0-dev.zip
py26 runtests: PYTHONHASHSEED='2566728021'
py26 runtests: commands[0] | nosetests --where=social/tests --stop
# .....................................................................................................................E
## ERROR: test_login (social.tests.backends.test_google.GoogleOpenIdTest)

Traceback (most recent call last):
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/test_google.py", line 253, in test_login
    self.do_login()
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/base.py", line 63, in do_login
    user = self.do_start()
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/open_id.py", line 119, in do_start
    return self.backend.complete()
  File "/Users/pyrak/workspace/python-social-auth/social/backends/base.py", line 40, in complete
    return self.auth_complete(_args, *_kwargs)
  File "/Users/pyrak/workspace/python-social-auth/social/backends/open_id.py", line 170, in auth_complete
    self.process_error(response)
  File "/Users/pyrak/workspace/python-social-auth/social/backends/open_id.py", line 178, in process_error
    raise AuthFailed(self, data.message)
AuthFailed: Authentication failed: Nonce already used or out of range
-------------------- >> begin captured logging << --------------------
requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): www.google.com
requests.packages.urllib3.connectionpool: DEBUG: "POST /accounts/o8/ud?source=mail HTTP/1.1" 200 1413
--------------------- >> end captured logging << ---------------------

---

Ran 118 tests in 2.466s

FAILED (errors=1)
ERROR: InvocationError: '/Users/pyrak/workspace/python-social-auth/.tox/py26/bin/nosetests --where=social/tests --stop'
py27 create: /Users/pyrak/workspace/python-social-auth/.tox/py27
py27 installdeps: -r/Users/pyrak/workspace/python-social-auth/social/tests/requirements.txt
py27 inst: /Users/pyrak/workspace/python-social-auth/.tox/dist/python-social-auth-0.2.0-dev.zip
py27 runtests: PYTHONHASHSEED='2566728021'
py27 runtests: commands[0] | nosetests --where=social/tests --stop
# .....................................................................................................................E
## ERROR: test_login (social.tests.backends.test_google.GoogleOpenIdTest)

Traceback (most recent call last):
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/test_google.py", line 253, in test_login
    self.do_login()
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/base.py", line 63, in do_login
    user = self.do_start()
  File "/Users/pyrak/workspace/python-social-auth/social/tests/backends/open_id.py", line 119, in do_start
    return self.backend.complete()
  File "/Users/pyrak/workspace/python-social-auth/social/backends/base.py", line 40, in complete
    return self.auth_complete(_args, *_kwargs)
  File "/Users/pyrak/workspace/python-social-auth/social/backends/open_id.py", line 170, in auth_complete
    self.process_error(response)
  File "/Users/pyrak/workspace/python-social-auth/social/backends/open_id.py", line 178, in process_error
    raise AuthFailed(self, data.message)
AuthFailed: Authentication failed: Nonce already used or out of range
-------------------- >> begin captured logging << --------------------
requests.packages.urllib3.connectionpool: INFO: Starting new HTTPS connection (1): www.google.com
requests.packages.urllib3.connectionpool: DEBUG: "POST /accounts/o8/ud?source=mail HTTP/1.1" 200 1413
--------------------- >> end captured logging << ---------------------

---

Ran 118 tests in 2.336s

FAILED (errors=1)
ERROR: InvocationError: '/Users/pyrak/workspace/python-social-auth/.tox/py27/bin/nosetests --where=social/tests --stop'
py33 create: /Users/pyrak/workspace/python-social-auth/.tox/py33
ERROR: InterpreterNotFound: python3.3
py34 create: /Users/pyrak/workspace/python-social-auth/.tox/py34
ERROR: InterpreterNotFound: python3.4
doc create: /Users/pyrak/workspace/python-social-auth/.tox/doc
doc installdeps: sphinx
doc inst: /Users/pyrak/workspace/python-social-auth/.tox/dist/python-social-auth-0.2.0-dev.zip
doc runtests: PYTHONHASHSEED='2566728021'
doc runtests: commands[0] | sphinx-build -b html -d /Users/pyrak/workspace/python-social-auth/.tox/doc/tmp/doctrees . /Users/pyrak/workspace/python-social-auth/.tox/doc/tmp/html
Making output directory...
Running Sphinx v1.2.2
loading pickled environment... not yet created
loading intersphinx inventory from http://docs.python.org/objects.inv...
building [html]: targets for 97 source files that are out of date
updating environment: 97 added, 0 changed, 0 removed
reading sources... [100%] use_cases  
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] use_cases  
writing additional files... (0 module code pages) genindex search
copying static files... done
copying extra files... done
dumping search index... done
dumping object inventory... done
build succeeded.
________________________________________ summary _________________________________________
ERROR:   py26: commands failed
ERROR:   py27: commands failed
ERROR:   py33: InterpreterNotFound: python3.3
ERROR:   py34: InterpreterNotFound: python3.4
  doc: commands succeeded
