### PR TITLE
Updated OpenId Connect Test Mixin

### DIFF
--- a/social/tests/backends/test_google.py
+++ b/social/tests/backends/test_google.py
@@ -275,7 +275,3 @@ class GoogleOpenIdConnectTest(OpenIdConnectTestMixin, GoogleOAuth2Test):
     user_data_url = \
         'https://www.googleapis.com/plus/v1/people/me/openIdConnect'
     issuer = "accounts.google.com"
-
-    def setUp(self):
-        GoogleOAuth2Test.setUp(self)
-        self.access_token_body = self.parse_nonce_and_return_access_token_body


### PR DESCRIPTION
- Renamed parse_nonce_and_return_access_token_body to access_token_body so
  that inheriting classes no longer need to set access_token_body
- Added method to retrieve id_token so that inheriting classes can modify the
  id_token response
