### PR TITLE
Removed utf-8 param in shopify backend

### DIFF
--- a/social/backends/shopify.py
+++ b/social/backends/shopify.py
@@ -32,7 +32,7 @@ class ShopifyOAuth2(BaseOAuth2):
     def get_user_details(self, response):
         """Use the shopify store name as the username"""
         return {
-            'username': six.text_type(response.get('shop', ''), 'utf-8')
+            'username': six.text_type(response.get('shop', ''))
                                 .replace('.myshopify.com', '')
         }
 


### PR DESCRIPTION
String is already unicode: otherwise it  will throw decoding unicode is not supported TypeError
