### PR TITLE
Allow more Trello settings

### DIFF
--- a/docs/backends/trello.rst
+++ b/docs/backends/trello.rst
@@ -12,5 +12,15 @@ In order to enable it, follow:
     SOCIAL_AUTH_TRELLO_KEY = '...'
     SOCIAL_AUTH_TRELLO_SECRET = '...'
 
+There are also two optional settings:
+
+- your app name, otherwise the authorization page will say "Let An unknown application use your account?"::
+
+    SOCIAL_AUTH_TRELLO_APP_NAME = 'My App'
+
+- the expiration period, social auth defaults to 'never', but you can change it::
+
+    SOCIAL_AUTH_TRELLO_EXPIRATION = '30days'
+
 
 .. _Trello Developers API Keys: https://trello.com/1/appKey/generate

--- a/social/backends/trello.py
+++ b/social/backends/trello.py
@@ -38,3 +38,10 @@ class TrelloOAuth(BaseOAuth1):
             return self.get_json(url, auth=self.oauth_auth(access_token))
         except ValueError:
             return None
+
+    def auth_extra_arguments(self):
+        return {
+            'name': self.setting('APP_NAME', ''),
+            # trello default expiration is '30days'
+            'expiration': self.setting('EXPIRATION', 'never')
+        }


### PR DESCRIPTION
This is how the authorization screen looks like withe current social auth.
It says "Let **An unknown application** use your account?" and the auth token expires after 30 days (which I thought was anoying).

![before](https://cloud.githubusercontent.com/assets/385177/4285577/4a08840a-3d88-11e4-8843-e59265d0942e.png)

I added two optional settings:

```
SOCIAL_AUTH_TRELLO_APP_NAME = 'Best App Ever'
SOCIAL_AUTH_TRELLO_EXPIRATION = 'never'
```

-->

![after](https://cloud.githubusercontent.com/assets/385177/4285576/49eeeb44-3d88-11e4-8a92-b1fec6f83f93.png)
