### PR TITLE
master  add SCOPE_SEPARATOR to DisqusOAuth2

### DIFF
--- a/social/backends/disqus.py
+++ b/social/backends/disqus.py
@@ -10,6 +10,7 @@ class DisqusOAuth2(BaseOAuth2):
     AUTHORIZATION_URL = 'https://disqus.com/api/oauth/2.0/authorize/'
     ACCESS_TOKEN_URL = 'https://disqus.com/api/oauth/2.0/access_token/'
     ACCESS_TOKEN_METHOD = 'POST'
+    SCOPE_SEPARATOR = ','
     EXTRA_DATA = [
         ('avatar', 'avatar'),
         ('connections', 'connections'),


### PR DESCRIPTION
Adding `SCOPE_SEPARATOR` to `social.backends.disqus.DisqusOAuth2`.

According to Disqus OAuth 2 documentation it can receive scope parameters separated by comma:

```
Location: https://disqus.com/api/oauth/2.0/authorize/?
client_id=PUBLIC_KEY&
scope=read,write&
response_type=code&
redirect_uri=http://www.example.com/oauth_redirect
```

https://disqus.com/api/docs/auth/

So, for example, one can add `email` to scope parameters end obtain user's email as extra data.
