### PR TITLE
Recreate migration with Django 1.7 final and re-PEP8.

### DIFF
--- a/social/apps/django_app/default/migrations/0001_initial.py
+++ b/social/apps/django_app/default/migrations/0001_initial.py
@@ -2,13 +2,13 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-from django.conf import settings
-
-import social.storage.django_orm
 import social.apps.django_app.default.fields
+from django.conf import settings
+import social.storage.django_orm
 
 
 class Migration(migrations.Migration):
+
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
@@ -17,8 +17,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Association',
             fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True,
-                                        auto_created=True, verbose_name='ID')),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('server_url', models.CharField(max_length=255)),
                 ('handle', models.CharField(max_length=255)),
                 ('secret', models.CharField(max_length=255)),
@@ -30,17 +30,15 @@ class Migration(migrations.Migration):
                 'db_table': 'social_auth_association',
             },
             bases=(
-                models.Model,
-                social.storage.django_orm.DjangoAssociationMixin
-            ),
+                models.Model, social.storage.django_orm.DjangoAssociationMixin),
         ),
         migrations.CreateModel(
             name='Code',
             fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True,
-                                        auto_created=True, verbose_name='ID')),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('email', models.EmailField(max_length=75)),
-                ('code', models.CharField(db_index=True, max_length=32)),
+                ('code', models.CharField(max_length=32, db_index=True)),
                 ('verified', models.BooleanField(default=False)),
             ],
             options={
@@ -48,15 +46,11 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model, social.storage.django_orm.DjangoCodeMixin),
         ),
-        migrations.AlterUniqueTogether(
-            name='code',
-            unique_together=set([('email', 'code')]),
-        ),
         migrations.CreateModel(
             name='Nonce',
             fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True,
-                                        auto_created=True, verbose_name='ID')),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('server_url', models.CharField(max_length=255)),
                 ('timestamp', models.IntegerField()),
                 ('salt', models.CharField(max_length=65)),
@@ -69,14 +63,14 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='UserSocialAuth',
             fields=[
-                ('id', models.AutoField(serialize=False, primary_key=True,
-                                        auto_created=True, verbose_name='ID')),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('provider', models.CharField(max_length=32)),
                 ('uid', models.CharField(max_length=255)),
-                ('extra_data',
-                 social.apps.django_app.default.fields.JSONField(default='{}')
-                ),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('extra_data', social.apps.django_app.default.fields.JSONField(
+                    default=b'{}')),
+                ('user', models.ForeignKey(
+                    related_name=b'social_auth', to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'social_auth_usersocialauth',
@@ -86,5 +80,9 @@ class Migration(migrations.Migration):
         migrations.AlterUniqueTogether(
             name='usersocialauth',
             unique_together=set([('provider', 'uid')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='code',
+            unique_together=set([('email', 'code')]),
         ),
     ]


### PR DESCRIPTION
This seems to work around a false-positive migration being created even if nothing has actually changed.

A similar problem occurred in easy-thumbnails: https://github.com/SmileyChris/easy-thumbnails/commit/b95e6888cd7bea9c5138b72bdbcd1e743655580f
