### PR TITLE
[flask_example_app]: Incorrect import path for db model

### DIFF
--- a/examples/flask_example/manage.py
+++ b/examples/flask_example/manage.py
@@ -19,7 +19,7 @@ manager.add_command('shell', Shell(make_context=lambda: {
 @manager.command
 def syncdb():
     from flask_example.models import user
-    from social.apps.flask_app import models
+    from social.apps.flask_app.default import models
     db.drop_all()
     db.create_all()
 


### PR DESCRIPTION
The flask example doesn't work as is due to an incorrect import path.
