### PR TITLE
Use new GoogleOAuth2 Spec

### DIFF
--- a/social/backends/google.py
+++ b/social/backends/google.py
@@ -84,7 +84,8 @@ class GoogleOAuth2(BaseGoogleOAuth2API, BaseOAuth2):
     ACCESS_TOKEN_METHOD = 'POST'
     REVOKE_TOKEN_URL = 'https://accounts.google.com/o/oauth2/revoke'
     REVOKE_TOKEN_METHOD = 'GET'
-    DEFAULT_SCOPE = ['email', 'profile']
+    # The order of the default scope is important
+    DEFAULT_SCOPE = ['openid', 'email', 'profile']
     DEPRECATED_DEFAULT_SCOPE = [
         'https://www.googleapis.com/auth/userinfo.email',
         'https://www.googleapis.com/auth/userinfo.profile'


### PR DESCRIPTION
As per #406 we've added in the openid to the GoogleOAuth2 class as per the documentation located [here](https://developers.google.com/accounts/docs/OAuth2Login).

It's important to note here that openid must be first in the list of scopes as per the documentation. @avances123 this is the pull request I referenced in IRC
