### PR TITLE
Added Django 1.7 App Config

### DIFF
--- a/social/apps/django_app/default/__init__.py
+++ b/social/apps/django_app/default/__init__.py
@@ -5,3 +5,5 @@ To enable this app:
     * Add 'social.apps.django_app.default' to INSTALLED_APPS
     * In urls.py include url('', include('social.apps.django_app.urls'))
 """
+
+default_app_config = 'social.apps.django_app.default.apps.PythonSocialAuthConfig'

--- a/social/apps/django_app/default/apps.py
+++ b/social/apps/django_app/default/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PythonSocialAuthConfig(AppConfig):
+    name = 'social.apps.django_app.default'
+    verbose_name = 'Python Social Auth'


### PR DESCRIPTION
- Renames the verbose app title to `Python Social Auth` in the Django admin for `Django >=1.7`
  ![screen shot 2014-10-04 at 10 38 59 am](https://cloud.githubusercontent.com/assets/791000/4515835/4609aca2-4bd5-11e4-9de0-da1092b8860d.png)
- Remains the title `Default` for `Django <1.7`
  ![screen shot 2014-10-04 at 10 47 20 am](https://cloud.githubusercontent.com/assets/791000/4515841/72128b8e-4bd5-11e4-8606-0f99c56c6a37.png)

Users will still use 

```
INSTALLED_APPS = [
    'social.apps.django_app.default',
    # ...
]
```
