### PR TITLE
Added Python 3.4 and PyPy to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "pypy"
 install:
   - "python setup.py -q install"
-  - "pip install -r social/tests/requirements.txt --use-mirrors"
+  - "travis_retry pip install -r social/tests/requirements.txt"
 script:
   - "nosetests --with-coverage --cover-package=social --where=social/tests"


### PR DESCRIPTION
Also use travis_retry instead of --use-mirrors in order to prevent build failures due to network issues because --use-mirrors is deprecated.
