### PR TITLE
Fix migration issue on python 3

### DIFF
--- a/social/apps/django_app/default/migrations/0001_initial.py
+++ b/social/apps/django_app/default/migrations/0001_initial.py
@@ -75,7 +75,7 @@ class Migration(migrations.Migration):
                 ('extra_data', social.apps.django_app.default.fields.JSONField(
                     default=b'{}')),
                 ('user', models.ForeignKey(
-                    related_name=b'social_auth', to=settings.AUTH_USER_MODEL)),
+                    related_name='social_auth', to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'db_table': 'social_auth_usersocialauth',


### PR DESCRIPTION
Django calls `related_name % {...}` in RelatedField.contribute_to_class which does not work on Python 3 as it does not support string formatting on byte-strings.
