### PR TITLE
Fix custom user model migrations for Django 1.7

### DIFF
--- a/social/apps/django_app/default/migrations/0001_initial.py
+++ b/social/apps/django_app/default/migrations/0001_initial.py
@@ -5,12 +5,16 @@ from django.db import models, migrations
 import social.apps.django_app.default.fields
 from django.conf import settings
 import social.storage.django_orm
+from social.utils import setting_name
 
+user_model = getattr(settings, setting_name('USER_MODEL'), None) or \
+             getattr(settings, 'AUTH_USER_MODE', None) or \
+             'auth.User'
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(user_model),
     ]
 
     operations = [
@@ -75,7 +79,7 @@ class Migration(migrations.Migration):
                 ('extra_data', social.apps.django_app.default.fields.JSONField(
                     default=b'{}')),
                 ('user', models.ForeignKey(
-                    related_name='social_auth', to=settings.AUTH_USER_MODEL)),
+                    related_name='social_auth', to=user_model)),
             ],
             options={
                 'db_table': 'social_auth_usersocialauth',


### PR DESCRIPTION
UserSocialAuth migration was depending on user.Auth by default and not
using the user model specified by SOCIAL_AUTH_USER_MODEL
