### PR TITLE
Update Django instructions to fix South migrations

### DIFF
--- a/docs/configuration/django.rst
+++ b/docs/configuration/django.rst
@@ -40,7 +40,14 @@ Database
 
     ./manage.py makemigrations
 
+If you're still using South, you'll need override SOUTH_MIGRATION_MODULES_::
 
+    SOUTH_MIGRATION_MODULES = {
+        'default': 'social.apps.django_app.default.south_migrations'
+    }
+    
+Note that Django's app labels take the last part of the import, so
+in this case ``social.apps.django_app.default`` becomes ``default`` here.
 
 Sync database to create needed models::
 
@@ -204,3 +211,4 @@ The fields listed **must** be user models fields.
 .. _Django built-in app: https://github.com/omab/python-social-auth/tree/master/social/apps/django_app
 .. _AUTHENTICATION_BACKENDS: http://docs.djangoproject.com/en/dev/ref/settings/?from=olddocs#authentication-backends
 .. _django@dc43fbc: https://github.com/django/django/commit/dc43fbc2f21c12e34e309d0e8a121020391aa03a
+.. _SOUTH_MIGRATION_MODULES: http://south.readthedocs.org/en/latest/settings.html#south-migration-modules


### PR DESCRIPTION
Instructions are broken when using South / Django 1.6 as South will try to use the default 'migrations' directory and fail.

This tells South to use the alternate directory.