### PR TITLE
YahooOAuth failed to get primary email if multiple email found in the profile.

### DIFF
--- a/social/backends/yahoo.py
+++ b/social/backends/yahoo.py
@@ -34,7 +34,7 @@ class YahooOAuth(BaseOAuth1):
         )
         emails = [email for email in response.get('emails', [])
                         if email.get('handle')]
-        emails.sort(key=lambda e: e.get('primary', False))
+        emails.sort(key=lambda e: e.get('primary', False), reverse=True)
         return {'username': response.get('nickname'),
                 'email': emails[0]['handle'] if emails else '',
                 'fullname': fullname,

--- a/social/tests/backends/test_yahoo.py
+++ b/social/tests/backends/test_yahoo.py
@@ -1,4 +1,5 @@
 import json
+import requests
 from httpretty import HTTPretty
 
 from social.p3 import urlencode
@@ -41,7 +42,19 @@ class YahooOAuth1Test(OAuth1Test):
             'isConnected': False,
             'profileUrl': 'http://profile.yahoo.com/a-guid',
             'guid': 'a-guid',
-            'nickname': 'foobar'
+            'nickname': 'foobar',
+            'emails': [{
+                'handle': 'foobar@yahoo.com',
+                'id': 1,
+                'primary': True,
+                'type': 'HOME',
+            },
+            {
+                'handle': 'foobar@email.com',
+                'id': 2,
+                'type': 'HOME',
+            }],
+            
         }
     })
 
@@ -56,3 +69,14 @@ class YahooOAuth1Test(OAuth1Test):
 
     def test_partial_pipeline(self):
         self.do_partial_pipeline()
+        
+    def test_get_user_details(self):
+        HTTPretty.register_uri(
+            HTTPretty.GET,
+            self.user_data_url,
+            status=200,
+            body=self.user_data_body
+        )
+        response = requests.get(self.user_data_url)
+        user_details=self.backend.get_user_details(response.json()['profile'])
+        self.assertEqual(user_details['email'], 'foobar@yahoo.com')


### PR DESCRIPTION
The sorting method to get the primary email email is reversed. 

Note the default behavior of python sorting on a Boolean arrays is to putting False first. for example.
>>> a=[True,False]
>>> a.sort()
>>> a
[False, True]
