### PR TITLE
Store Spotify's refresh_token.

### DIFF
--- a/social/backends/spotify.py
+++ b/social/backends/spotify.py
@@ -16,6 +16,9 @@ class SpotifyOAuth2(BaseOAuth2):
     ACCESS_TOKEN_URL = 'https://accounts.spotify.com/api/token'
     ACCESS_TOKEN_METHOD = 'POST'
     REDIRECT_STATE = False
+    EXTRA_DATA = [
+        ('refresh_token', 'refresh_token'),
+    ]
 
     def auth_headers(self):
         return {


### PR DESCRIPTION
Spotify's `access_token` expires after a few hours. To be able to refresh the token, we need to be storing `refresh_token`.