### PR TITLE
Freezing PyJWT at 0.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=1.1.0
 oauthlib>=0.3.8
 requests-oauthlib>=0.3.0
 six>=1.2.0
-PyJWT==0.2.1
+PyJWT==0.2.3

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_packages():
     return packages
 
 
-requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0', 'PyJWT>=0.2.1']
+requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0', 'PyJWT==0.2.3']
 if PY3:
     requires += ['python3-openid>=3.0.1',
                  'requests-oauthlib>=0.3.0,<0.3.2']


### PR DESCRIPTION
PyJWT 0.3.0 introduced an audience validation. The OIDC backend already has its own method of audience validation that I'd prefer to stick with since it's already tested (and I don't have time at the moment to update the code to use the validation in PyJWT).