### PR TITLE
Enable url patterns in settings urls

### DIFF
--- a/docs/configuration/settings.rst
+++ b/docs/configuration/settings.rst
@@ -64,6 +64,9 @@ URLs options
 These URLs are used on different steps of the auth process, some for successful
 results and others for error situations.
 
+``SOCIAL_AUTH_URL_PATTERNS_ENABLED = False``
+    Enables url patterns in the url settings below.
+
 ``SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/logged-in/'``
     Used to redirect the user once the auth process ended successfully. The
     value of ``?next=/foo`` is used if it was present


### PR DESCRIPTION
In order to allow url patters in the settings urls set SOCIAL_AUTH_URL_PATTERNS_ENABLED = True (by default it's disabled to maintain backward compatibility).