### PR TITLE
Ensure email is not None

### DIFF
--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -96,6 +96,7 @@ class OpenIdAuth(BaseAuth):
         fullname = values.get('fullname') or ''
         first_name = values.get('first_name') or ''
         last_name = values.get('last_name') or ''
+        email = values.get('email') or ''
 
         if not fullname and first_name and last_name:
             fullname = first_name + ' ' + last_name
@@ -109,7 +110,8 @@ class OpenIdAuth(BaseAuth):
         values.update({'fullname': fullname, 'first_name': first_name,
                        'last_name': last_name,
                        'username': values.get(username_key) or
-                                   (first_name.title() + last_name.title())})
+                                   (first_name.title() + last_name.title()),
+                       'email': email})
         return values
 
     def extra_data(self, user, uid, response, details):


### PR DESCRIPTION
If a user chooses not to share their email via the OpenId login page,
we end up passing through None as the 'email' value, which ends up
raising a "column 'email' cannot be null" error on some databases.
Blank string is fine.