### PR TITLE
Updated PyJWT Dependency

### DIFF
--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -3,4 +3,4 @@ requests>=1.1.0
 oauthlib>=0.3.8
 requests-oauthlib>=0.3.0,<0.3.2
 six>=1.2.0
-PyJWT==0.2.1
+PyJWT==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=1.1.0
 oauthlib>=0.3.8
 requests-oauthlib>=0.3.0
 six>=1.2.0
-PyJWT==0.2.1
+PyJWT==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_packages():
     return packages
 
 
-requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0', 'PyJWT>=0.2.1']
+requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0', 'PyJWT==0.4.1']
 if PY3:
     requires += ['python3-openid>=3.0.1',
                  'requests-oauthlib>=0.3.0,<0.3.2']

--- a/social/tests/backends/open_id.py
+++ b/social/tests/backends/open_id.py
@@ -216,11 +216,11 @@ class OpenIdConnectTestMixin(object):
                               expiration_datetime=expiration_datetime)
 
     def test_invalid_issuer(self):
-        self.authtoken_raised('Token error: Incorrect id_token: iss',
+        self.authtoken_raised('Token error: Invalid issuer',
                               issuer='someone-else')
 
     def test_invalid_audience(self):
-        self.authtoken_raised('Token error: Incorrect id_token: aud',
+        self.authtoken_raised('Token error: Invalid audience',
                               client_key='someone-else')
 
     def test_invalid_issue_time(self):

--- a/social/tests/requirements-python3.txt
+++ b/social/tests/requirements-python3.txt
@@ -3,5 +3,5 @@ coverage>=3.6
 mock==1.0.1
 nose>=1.2.1
 requests>=1.1.0
-PyJWT==0.2.1
+PyJWT==0.4.1
 unittest2py3k==0.5.1

--- a/social/tests/requirements.txt
+++ b/social/tests/requirements.txt
@@ -3,5 +3,5 @@ coverage>=3.6
 mock==1.0.1
 nose>=1.2.1
 requests>=1.1.0
-PyJWT==0.2.1
+PyJWT==0.4.1
 unittest2==0.5.1


### PR DESCRIPTION
- Using PyJWT 0.4.1 (or newer)
- Relying on PyJWT to verify ID token audience and issuer

Replaces #486.