### PR TITLE
[facebook-oauth2] Verifying Graph API Calls with appsecret_proof

### DIFF
--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -13,6 +13,11 @@ from social.backends.oauth import BaseOAuth2
 from social.exceptions import AuthException, AuthCanceled, AuthUnknownError, \
                               AuthMissingParameter
 
+import hmac
+import hashlib
+
+def hmac_sha256(key, msg):
+    return hmac.new(key, msg, digestmod=hashlib.sha256).hexdigest()
 
 class FacebookOAuth2(BaseOAuth2):
     """Facebook OAuth2 authentication backend"""
@@ -46,6 +51,11 @@ class FacebookOAuth2(BaseOAuth2):
         """Loads user data from service"""
         params = self.setting('PROFILE_EXTRA_PARAMS', {})
         params['access_token'] = access_token
+
+        if self.setting('APPSECRET_PROOF', True):
+            _, secret = self.get_key_and_secret()
+            params['appsecret_proof'] = hmac_sha256(secret, access_token);
+
         return self.get_json(self.USER_DATA_URL, params=params)
 
     def process_error(self, data):


### PR DESCRIPTION
https://developers.facebook.com/docs/graph-api/securing-requests

Graph API calls from a server can be better secured by adding a
parameter called appsecret_proof.

The app secret proof is a sha256 hash of your access token, using the
app secret as the key.

$appsecret_proof= hash_hmac('sha256', $access_token, $app_secret)

the result as an appsecret_proof parameter must be added to each call
you make from server.

Securing with appsecret_proof is optional (but enabled by default for
new Facebook apps) so add appsecret_proof param is contoled by
SOCIAL_AUTH_FACEBOOK_APPSECRET_PROOF = True|False

Default is True