### PR TITLE
Include username in Reddit extra_data

### DIFF
--- a/social/backends/reddit.py
+++ b/social/backends/reddit.py
@@ -20,6 +20,7 @@ class RedditOAuth2(BaseOAuth2):
     SEND_USER_AGENT = True
     EXTRA_DATA = [
         ('id', 'id'),
+        ('name', 'username'),
         ('link_karma', 'link_karma'),
         ('comment_karma', 'comment_karma'),
         ('refresh_token', 'refresh_token'),


### PR DESCRIPTION
Currently, the Reddit username is used to generate a username when creating a new user, but for existing users it doesn't get stored in the database. This fix adds the username to `extra_data`, aliasing the Reddit attribute `name` to the `extra_data` attribute `username`, thus letting you more reliably know your users' Reddit usernames.