### PR TITLE
Don't use "import" in example method paths docs to avoid confusion

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -330,7 +330,7 @@ the pipeline, since it needs the user instance, it needs to be put after
         'social.pipeline.social_auth.social_user',
         'social.pipeline.user.get_username',
         'social.pipeline.user.create_user',
-        'import.path.to.save_profile',  # <--- set the import-path to the function
+        'path.to.save_profile',  # <--- set the path to the function
         'social.pipeline.social_auth.associate_user',
         'social.pipeline.social_auth.load_extra_data',
         'social.pipeline.user.user_details'

--- a/docs/use_cases.rst
+++ b/docs/use_cases.rst
@@ -287,7 +287,7 @@ Set this pipeline after ``social_user``::
         'social.pipeline.social_auth.social_uid',
         'social.pipeline.social_auth.auth_allowed',
         'social.pipeline.social_auth.social_user',
-        'import.path.to.redirect_if_no_refresh_token',
+        'path.to.redirect_if_no_refresh_token',
         'social.pipeline.user.get_username',
         'social.pipeline.user.create_user',
         'social.pipeline.social_auth.associate_user',


### PR DESCRIPTION
This is for two reasons:

 a) Using the verb "import" suggests that the module/function should be
    imported which is not true; we want a "dotted path notation" string
    rather than a reference to the method.

 b) "import" is an invalid module name anyway, so as an example of dotted
    path notation it is faulty. (Okay, it might actually be possible using
    `types` and `sys.modules` but.. yeah)

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>