### PR TITLE
fix python3 handling of openid backend on sqlalchemy storage

### DIFF
--- a/social/storage/sqlalchemy_orm.py
+++ b/social/storage/sqlalchemy_orm.py
@@ -181,7 +181,7 @@ class SQLAlchemyAssociationMixin(SQLAlchemyMixin, AssociationMixin):
         except IndexError:
             assoc = cls(server_url=server_url,
                         handle=association.handle)
-        assoc.secret = base64.encodestring(association.secret)
+        assoc.secret = base64.encodestring(association.secret).decode()
         assoc.issued = association.issued
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type


### PR DESCRIPTION
base64.encodestring() returns "bytes" type, this fails type check with sqlalchemy (pypostgresql driver for sqlalchemy here) with python3.

Calling .decode() converts the result to "str" type, and database insert/update works.
This patch also works with python2 (converting from "str" to "unicode").