### PR TITLE
Add backend for EVE Online Single Sign-On (OAuth2)

### DIFF
--- a/docs/backends/eveonline.rst
+++ b/docs/backends/eveonline.rst
@@ -1,0 +1,21 @@
+EVE Online Single Sign-On (SSO)
+===============================
+
+The EVE Single Sign-On (SSO) works similar to GitHub (OAuth2).
+
+- Register a new application at `EVE Developers`_, set the callback URL to
+  ``http://example.com/complete/eveonline/`` replacing ``example.com`` with your
+  domain.
+
+- Fill the ``Client ID`` and ``Secret Key`` values from EVE Developers in the settings::
+
+      SOCIAL_AUTH_EVEONLINE_KEY = ''
+      SOCIAL_AUTH_EVEONLINE_SECRET = ''
+
+- If you want to use EVE Character names as user names, use this setting::
+
+      SOCIAL_AUTH_CLEAN_USERNAMES = False
+
+- If you want to access EVE Online's CREST API, use::
+
+      SOCIAL_AUTH_EVEONLINE_SCOPE = ['publicData']

--- a/examples/cherrypy_example/local_settings.py.template
+++ b/examples/cherrypy_example/local_settings.py.template
@@ -24,6 +24,7 @@ SOCIAL_SETTINGS = {
         'social.backends.dailymotion.DailymotionOAuth2',
         'social.backends.disqus.DisqusOAuth2',
         'social.backends.dropbox.DropboxOAuth',
+        'social.backends.eveonline.EVEOnlineOAuth2',
         'social.backends.evernote.EvernoteSandboxOAuth',
         'social.backends.fitbit.FitbitOAuth',
         'social.backends.flickr.FlickrOAuth',

--- a/examples/django_example/example/settings.py
+++ b/examples/django_example/example/settings.py
@@ -136,6 +136,7 @@ AUTHENTICATION_BACKENDS = (
     'social.backends.douban.DoubanOAuth2',
     'social.backends.dropbox.DropboxOAuth',
     'social.backends.dropbox.DropboxOAuth2',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.facebook.FacebookAppOAuth2',
     'social.backends.facebook.FacebookOAuth2',

--- a/examples/django_me_example/example/settings.py
+++ b/examples/django_me_example/example/settings.py
@@ -151,6 +151,7 @@ AUTHENTICATION_BACKENDS = (
     'social.backends.dailymotion.DailymotionOAuth2',
     'social.backends.disqus.DisqusOAuth2',
     'social.backends.dropbox.DropboxOAuth',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.fitbit.FitbitOAuth',
     'social.backends.flickr.FlickrOAuth',

--- a/examples/flask_example/settings.py
+++ b/examples/flask_example/settings.py
@@ -35,6 +35,7 @@ SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
     'social.backends.dailymotion.DailymotionOAuth2',
     'social.backends.disqus.DisqusOAuth2',
     'social.backends.dropbox.DropboxOAuth',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.fitbit.FitbitOAuth',
     'social.backends.flickr.FlickrOAuth',

--- a/examples/flask_me_example/settings.py
+++ b/examples/flask_me_example/settings.py
@@ -40,6 +40,7 @@ SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
     'social.backends.dailymotion.DailymotionOAuth2',
     'social.backends.disqus.DisqusOAuth2',
     'social.backends.dropbox.DropboxOAuth',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.fitbit.FitbitOAuth',
     'social.backends.flickr.FlickrOAuth',

--- a/examples/pyramid_example/example/settings.py
+++ b/examples/pyramid_example/example/settings.py
@@ -29,6 +29,7 @@ SOCIAL_AUTH_SETTINGS = {
         'social.backends.dailymotion.DailymotionOAuth2',
         'social.backends.disqus.DisqusOAuth2',
         'social.backends.dropbox.DropboxOAuth',
+        'social.backends.eveonline.EVEOnlineOAuth2',
         'social.backends.evernote.EvernoteSandboxOAuth',
         'social.backends.fitbit.FitbitOAuth',
         'social.backends.flickr.FlickrOAuth',

--- a/examples/tornado_example/settings.py
+++ b/examples/tornado_example/settings.py
@@ -28,6 +28,7 @@ SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
     'social.backends.dailymotion.DailymotionOAuth2',
     'social.backends.disqus.DisqusOAuth2',
     'social.backends.dropbox.DropboxOAuth',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.fitbit.FitbitOAuth',
     'social.backends.flickr.FlickrOAuth',

--- a/examples/webpy_example/app.py
+++ b/examples/webpy_example/app.py
@@ -41,6 +41,7 @@ web.config[setting_name('AUTHENTICATION_BACKENDS')] = (
     'social.backends.dailymotion.DailymotionOAuth2',
     'social.backends.disqus.DisqusOAuth2',
     'social.backends.dropbox.DropboxOAuth',
+    'social.backends.eveonline.EVEOnlineOAuth2',
     'social.backends.evernote.EvernoteSandboxOAuth',
     'social.backends.fitbit.FitbitOAuth',
     'social.backends.flickr.FlickrOAuth',

--- a/social/backends/eveonline.py
+++ b/social/backends/eveonline.py
@@ -1,0 +1,39 @@
+"""
+EVE Online Single Sign-On (SSO) OAuth2 backend
+Documentation at https://developers.eveonline.com/resource/single-sign-on
+"""
+from requests import HTTPError
+
+from social.exceptions import AuthFailed
+from social.backends.oauth import BaseOAuth2
+
+
+class EVEOnlineOAuth2(BaseOAuth2):
+    """EVE Online OAuth authentication backend"""
+    name = 'eveonline'
+    AUTHORIZATION_URL = 'https://login.eveonline.com/oauth/authorize'
+    ACCESS_TOKEN_URL = 'https://login.eveonline.com/oauth/token'
+    ID_KEY = "CharacterID"
+    ACCESS_TOKEN_METHOD = 'POST'
+    EXTRA_DATA = [
+        ('CharacterID', 'id'),
+        ('refresh_token', 'refresh_token', True),
+        ('expires_in', 'expires'),
+    ]
+
+    def get_user_details(self, response):
+        """Return user details from EVE Online account"""
+        user_data = self.user_data(response['access_token'])
+        print user_data
+        fullname, first_name, last_name = self.get_user_names(user_data['CharacterName'])
+        return {'username': fullname,
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name}
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Get Character data from EVE server"""
+        return self.get_json(
+            'https://login.eveonline.com/oauth/verify',
+            headers={'Authorization': "Bearer {0}".format(access_token)}
+        )


### PR DESCRIPTION
I have added a simple OAuth2 backend for the MMO "EVE Online".
https://developers.eveonline.com/resource/single-sign-on
http://www.eveonline.com/

Tested with the Django default example.