### PR TITLE
Declined Facebook permissions will be asked again when user goes through...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ sessions/
 _build/
 fabfile.py
 changelog.sh
+.idea/
 
 .DS_Store

--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -309,7 +309,8 @@ class BaseOAuth2(OAuthAuth):
         client_id, client_secret = self.get_key_and_secret()
         params = {
             'client_id': client_id,
-            'redirect_uri': self.get_redirect_uri(state)
+            'redirect_uri': self.get_redirect_uri(state),
+            'auth_type': 'rerequest'
         }
         if self.STATE_PARAMETER and state:
             params['state'] = state


### PR DESCRIPTION
From https://developers.facebook.com/docs/facebook-login/login-flow-for-web/v2.2#re-asking-declined-permissions.

> Facebook Login lets people decline sharing some permissions with your app.

With these changes these permissions that the user is asked are made mandatory. We should actually come up with a bertter way to fix by making ```SOCIAL_AUTH_FACEBOOK_SCOPE``` a tuple or a dict to identify if the permission is mandatory or not.