### PR TITLE
Require PyJWT>=1.0.0,<2.0.0

### DIFF
--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -3,4 +3,4 @@ requests>=1.1.0
 oauthlib>=0.3.8
 requests-oauthlib>=0.3.1,<0.3.2
 six>=1.2.0
-PyJWT==0.4.1
+PyJWT>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests>=1.1.0
 oauthlib>=0.3.8
 requests-oauthlib>=0.3.1
 six>=1.2.0
-PyJWT==0.4.1
+PyJWT>=1.0.0,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ def get_packages():
     return packages
 
 
-requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0', 'PyJWT==0.4.1']
+requires = ['requests>=1.1.0', 'oauthlib>=0.3.8', 'six>=1.2.0',
+            'PyJWT>=1.0.0,<2.0.0']
 if PY3:
     requires += ['python3-openid>=3.0.1',
                  'requests-oauthlib>=0.3.1,<0.3.2']

--- a/social/backends/exacttarget.py
+++ b/social/backends/exacttarget.py
@@ -61,7 +61,7 @@ class ExactTargetOAuth2(BaseOAuth2):
     def do_auth(self, token, *args, **kwargs):
         dummy, secret = self.get_key_and_secret()
         try:  # Decode the token, using the Application Signature from settings
-            decoded = jwt.decode(token, secret)
+            decoded = jwt.decode(token, secret, algorithms=['HS256'])
         except jwt.DecodeError:  # Wrong signature, fail authentication
             raise AuthCanceled(self)
         kwargs.update({'response': {'token': decoded}, 'backend': self})

--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -330,7 +330,8 @@ class OpenIdConnectAuth(BaseOAuth2):
             # Decode the JWT and raise an error if the secret is invalid or
             # the response has expired.
             id_token = jwt_decode(id_token, decryption_key, audience=client_id,
-                                  issuer=self.ID_TOKEN_ISSUER)
+                                  issuer=self.ID_TOKEN_ISSUER,
+                                  algorithms=['HS256'])
         except InvalidTokenError as err:
             raise AuthTokenError(self, err)
 

--- a/social/tests/backends/open_id.py
+++ b/social/tests/backends/open_id.py
@@ -193,7 +193,8 @@ class OpenIdConnectTestMixin(object):
             client_key, timegm(expiration_datetime.utctimetuple()),
             timegm(issue_datetime.utctimetuple()), nonce, issuer)
 
-        body['id_token'] = jwt.encode(id_token, client_secret).decode('utf-8')
+        body['id_token'] = jwt.encode(id_token, client_secret,
+                                      algorithm='HS256').decode('utf-8')
         return json.dumps(body)
 
     def authtoken_raised(self, expected_message, **access_token_kwargs):

--- a/social/tests/requirements-python3.txt
+++ b/social/tests/requirements-python3.txt
@@ -3,5 +3,5 @@ coverage>=3.6
 mock==1.0.1
 nose>=1.2.1
 requests>=1.1.0
-PyJWT==0.4.1
+PyJWT>=1.0.0,<2.0.0
 unittest2py3k==0.5.1

--- a/social/tests/requirements.txt
+++ b/social/tests/requirements.txt
@@ -3,5 +3,5 @@ coverage>=3.6
 mock==1.0.1
 nose>=1.2.1
 requests>=1.1.0
-PyJWT==0.4.1
+PyJWT>=1.0.0,<2.0.0
 unittest2==0.5.1


### PR DESCRIPTION
Yesterday we released PyJWT [v1.0.0](https://github.com/jpadilla/pyjwt/releases/tag/1.0.0) which fixes some reported security vulnerabilities. Although this project doesn't seem to be affected, it would still be good idea to require PyJWT>=1.0.0,<2.0.0 instead.