### PR TITLE
Add missing migration for Django app

### DIFF
--- a/social/apps/django_app/default/migrations/0002_add_related_name.py
+++ b/social/apps/django_app/default/migrations/0002_add_related_name.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='usersocialauth',
+            name='user',
+            field=models.ForeignKey(related_name='social_auth', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
The Django app is missing a migration due to Django 1.7 treating *any* changes to the model as migrations.

Ref #516 