### PR TITLE
Allow inactive users to login

### DIFF
--- a/social/actions.py
+++ b/social/actions.py
@@ -74,6 +74,9 @@ def do_complete(backend, login, user=None, redirect_name='next',
                 url = setting_url(backend, redirect_value,
                                   'LOGIN_REDIRECT_URL')
         else:
+            if backend.setting('SOCIAL_AUTH_INACTIVE_USER_LOGIN', False):
+                social_user = user.social_user
+                login(backend, user, social_user)
             url = setting_url(backend, 'INACTIVE_USER_URL', 'LOGIN_ERROR_URL',
                               'LOGIN_URL')
     else:


### PR DESCRIPTION
- Allow inactive users to login, this is controlled by the
  `SOCIAL_AUTH_INACTIVE_USER_LOGIN` setting.

I want to be able to allow inactive users to be logged in.  I have written a middleware that redirects these users to a reactivation page that currently requires the user to be logged in to work. 

I modified the `social.actions.do_complete` method so it would login inactive users depending on the setting `SOCIAL_AUTH_INACTIVE_USER_LOGIN`, which defaults to `False`. 