### PR TITLE
prevent reddit backend from clobbering user.email

### DIFF
--- a/social/backends/reddit.py
+++ b/social/backends/reddit.py
@@ -29,9 +29,7 @@ class RedditOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details from Reddit account"""
-        return {'username': response.get('name'),
-                'email': '', 'fullname': '',
-                'first_name': '', 'last_name': ''}
+        return {'username': response.get('name')}
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""


### PR DESCRIPTION
In my project using Reddit OAuth2, I noticed that `user.email` was being set to an empty string every time a user logged in, after previously logging out or having their session expire. I'm not sure if this is the best fix, but it worked for me.
