### PR TITLE
Append trailing slash in Django

### DIFF
--- a/social/apps/django_app/utils.py
+++ b/social/apps/django_app/utils.py
@@ -37,6 +37,8 @@ def psa(redirect_uri=None, load_strategy=load_strategy):
             uri = redirect_uri
             if uri and not uri.startswith('/'):
                 uri = reverse(redirect_uri, args=(backend,))
+                if settings.APPEND_SLASH and not uri.endswith('/'):
+                    uri = uri + '/'
 
             request.social_strategy = load_strategy(request)
             # backward compatibility in attribute name, only if not already


### PR DESCRIPTION
This commit https://github.com/omab/python-social-auth/commit/f57e0caf4ec06f3b9a2367d9ff3897e2a3a71608 made trailing slashes optional.
The side effect of that is that the redirect_uri is created without a trailing slash.
With this change the standard Django APPEND_SLASH is checked when generating the redirect url.