### PR TITLE
Alter email max length for Django app

### DIFF
--- a/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
+++ b/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default', '0002_add_related_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='code',
+            name='email',
+            field=models.EmailField(max_length=254),
+        ),
+    ]


### PR DESCRIPTION
Django 1.8 starts to set max length of EmailField to 254.