### PR TITLE
fix Fitbit OAuth 1 authorization URL

### DIFF
--- a/social/backends/fitbit.py
+++ b/social/backends/fitbit.py
@@ -8,7 +8,7 @@ from social.backends.oauth import BaseOAuth1
 class FitbitOAuth(BaseOAuth1):
     """Fitbit OAuth authentication backend"""
     name = 'fitbit'
-    AUTHORIZATION_URL = 'https://api.fitbit.com/oauth/authorize'
+    AUTHORIZATION_URL = 'https://www.fitbit.com/oauth/authorize'
     REQUEST_TOKEN_URL = 'https://api.fitbit.com/oauth/request_token'
     ACCESS_TOKEN_URL = 'https://api.fitbit.com/oauth/access_token'
     ID_KEY = 'encodedId'


### PR DESCRIPTION
According to
https://wiki.fitbit.com/display/API/OAuth+1.0a+Authentication#OAuth1.0aAuthentication-Notes,
the base url for the oauth authroization page is
https://www.fitbit.com, not https://api.fitbit.com. Soon they will
redirect authorize requests to [api](api.fitbit.com) to [www](www.fitbit.com),
which will increase page load time for end users