### PR TITLE
Adding Azure Active Directory support

### DIFF
--- a/docs/backends/azuread.rst
+++ b/docs/backends/azuread.rst
@@ -1,0 +1,19 @@
+Microsoft Azure Active Directory
+======
+
+To enable OAuth2 support:
+
+- Fill in ``Client ID`` and ``Client Secret`` settings. These values can be obtained
+  easily as described in `Azure AD Application Registration`_ doc::
+
+      SOCIAL_AUTH_AZUREAD_OAUTH2_KEY = ''
+      SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = ''
+
+- Also it's possible to define extra permissions with::
+
+      SOCIAL_AUTH_AZUREAD_OAUTH2_RESOURCE = ''
+
+      This is the resource you would like to access after authentication succeeds. 
+      Some of the possible values are: ``https://graph.windows.net`` or ``https://<your Sharepoint site name>-my.sharepoint.com``.
+
+.. _Azure AD Application Registration: https://msdn.microsoft.com/en-us/library/azure/dn132599.aspx

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2015 Microsoft Open Technologies, Inc.
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/social/backends/azuread.py
+++ b/social/backends/azuread.py
@@ -1,0 +1,79 @@
+"""
+Azure AD OAuth2 backend, docs at:
+    http://psa.matiasaguirre.net/docs/backends/azuread.html
+"""
+import datetime
+from calendar import timegm
+from social.exceptions import AuthException, AuthFailed, AuthCanceled, \
+                              AuthUnknownError, AuthMissingParameter, \
+                              AuthTokenError
+from jwt import DecodeError, ExpiredSignature, decode as jwt_decode
+from social.backends.oauth import BaseOAuth2
+import urllib
+
+class AzureADOAuth2(BaseOAuth2):
+    name = 'azuread-oauth2'
+    SCOPE_SEPARATOR = ' '
+    AUTHORIZATION_URL = 'https://login.windows.net/common/oauth2/authorize'
+    ACCESS_TOKEN_URL = 'https://login.windows.net/common/oauth2/token'
+    ACCESS_TOKEN_METHOD = 'POST'
+    REDIRECT_STATE = False
+    DEFAULT_SCOPE = ['openid', 'profile', 'user_impersonation']
+    EXTRA_DATA = [
+        ('access_token', 'access_token'),
+        ('id_token', 'id_token'),
+        ('refresh_token', 'refresh_token'),
+        ('expires_in', 'expires'),
+        ('given_name', 'first_name'),
+        ('family_name', 'last_name'),
+        ('token_type', 'token_type')
+    ]
+
+    def auth_extra_arguments(self):
+        """Return extra arguments needed on auth process. The defaults can be
+        overriden by GET parameters."""
+        extra_arguments = {}
+        resource = self.setting('SHAREPOINT_SITE')
+        
+        if resource:
+            extra_arguments = {
+                'resource': resource
+            }
+        
+        return extra_arguments
+
+    def get_user_id(self, details, response):
+        """Use upn as unique id"""
+        return response.get('upn')
+
+    def get_user_details(self, response):
+        """Return user details from Azure AD account"""
+        fullname, first_name, last_name = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', '')
+        )
+        return {'username': fullname,
+                'email': response.get('upn'),
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name}
+
+    def user_data(self, access_token, *args, **kwargs):
+        response = kwargs.get('response')
+        id_token = response.get('id_token')
+        
+        try:
+            decoded_id_token = jwt_decode(id_token, verify=False)
+        except (DecodeError, ExpiredSignature) as de:
+            raise AuthTokenError(self, de)
+        
+        return decoded_id_token
+
+    def extra_data(self, user, uid, response, details=None):
+        """Return access_token and extra defined names to store in
+        extra_data field"""
+        data = super(BaseOAuth2, self).extra_data(user, uid, response, details)
+        data['sharepoint_site'] = self.setting('SHAREPOINT_SITE')
+        return data
+

--- a/social/backends/azuread.py
+++ b/social/backends/azuread.py
@@ -29,19 +29,6 @@ class AzureADOAuth2(BaseOAuth2):
         ('token_type', 'token_type')
     ]
 
-    def auth_extra_arguments(self):
-        """Return extra arguments needed on auth process. The defaults can be
-        overriden by GET parameters."""
-        extra_arguments = {}
-        resource = self.setting('SHAREPOINT_SITE')
-        
-        if resource:
-            extra_arguments = {
-                'resource': resource
-            }
-        
-        return extra_arguments
-
     def get_user_id(self, details, response):
         """Use upn as unique id"""
         return response.get('upn')
@@ -74,6 +61,5 @@ class AzureADOAuth2(BaseOAuth2):
         """Return access_token and extra defined names to store in
         extra_data field"""
         data = super(BaseOAuth2, self).extra_data(user, uid, response, details)
-        data['sharepoint_site'] = self.setting('SHAREPOINT_SITE')
         return data
 

--- a/social/backends/azuread.py
+++ b/social/backends/azuread.py
@@ -1,4 +1,30 @@
 """
+Copyright (c) 2015 Microsoft Open Technologies, Inc.
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+"""
 Azure AD OAuth2 backend, docs at:
     http://psa.matiasaguirre.net/docs/backends/azuread.html
 """

--- a/social/backends/azuread.py
+++ b/social/backends/azuread.py
@@ -57,9 +57,22 @@ class AzureADOAuth2(BaseOAuth2):
         
         return decoded_id_token
 
+    def auth_extra_arguments(self):
+        """Return extra arguments needed on auth process. The defaults can be
+        overriden by GET parameters."""
+        extra_arguments = {}
+        resource = self.setting('RESOURCE')
+        
+        if resource:
+            extra_arguments = {
+                'resource': resource
+            }
+        
+        return extra_arguments
+
     def extra_data(self, user, uid, response, details=None):
         """Return access_token and extra defined names to store in
         extra_data field"""
         data = super(BaseOAuth2, self).extra_data(user, uid, response, details)
+        data['resource'] = self.setting('RESOURCE')
         return data
-

--- a/social/tests/backends/test_azuread.py
+++ b/social/tests/backends/test_azuread.py
@@ -1,0 +1,40 @@
+import json
+from social.p3 import urlencode
+from social.tests.backends.oauth import OAuth2Test
+
+class AzureADOAuth2Test(OAuth2Test):
+
+    backend_path = 'social.backends.azuread.AzureADOAuth2'
+    user_data_url = 'https://graph.windows.net/me'
+    expected_username = 'foobar'
+
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer',
+        'id_token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83Mjc0MDZhYy03MDY4'
+                    'LTQ4ZmEtOTJiOS1jMmQ2NzIxMWJjNTAvIiwiaWF0IjpudWxsLCJleHAiOm51bGwsImF1ZCI6IjAyOWNjMDEwLWJiNzQtNGQyY'
+                    'i1hMDQwLWY5Y2VkM2ZkMmM3NiIsInN1YiI6InFVOHhrczltSHFuVjZRMzR6aDdTQVpvY2loOUV6cnJJOW1wVlhPSWJWQTgiLC'
+                    'J2ZXIiOiIxLjAiLCJ0aWQiOiI3Mjc0MDZhYy03MDY4LTQ4ZmEtOTJiOS1jMmQ2NzIxMWJjNTAiLCJvaWQiOiI3ZjhlMTk2OS0'
+                    '4YjgxLTQzOGMtOGQ0ZS1hZDZmNTYyYjI4YmIiLCJ1cG4iOiJmb29iYXJAdGVzdC5vbm1pY3Jvc29mdC5jb20iLCJnaXZlbl9u'
+                    'YW1lIjoiZm9vIiwiZmFtaWx5X25hbWUiOiJiYXIiLCJuYW1lIjoiZm9vIGJhciIsInVuaXF1ZV9uYW1lIjoiZm9vYmFyQHRlc'
+                    '3Qub25taWNyb3NvZnQuY29tIiwicHdkX2V4cCI6IjQ3MzMwOTY4IiwicHdkX3VybCI6Imh0dHBzOi8vcG9ydGFsLm1pY3Jvc2'
+                    '9mdG9ubGluZS5jb20vQ2hhbmdlUGFzc3dvcmQuYXNweCJ9.3V50dHXTZOHj9UWtkn2g7BjX5JxNe8skYlK4PdhiLz4'
+    })
+
+    refresh_token_body = json.dumps({
+        'access_token': 'foobar-new-token',
+        'token_type': 'bearer',
+        'expires_in': 3600.0,
+        'refresh_token': 'foobar-new-refresh-token',
+        'scope': 'identity'
+    })
+
+    def test_login(self):
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        self.do_partial_pipeline()
+
+    def test_refresh_token(self):
+        user, social = self.do_refresh_token()
+        self.assertEqual(social.extra_data['access_token'], 'foobar-new-token')

--- a/social/tests/backends/test_azuread.py
+++ b/social/tests/backends/test_azuread.py
@@ -1,3 +1,29 @@
+"""
+Copyright (c) 2015 Microsoft Open Technologies, Inc.
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 import json
 from social.p3 import urlencode
 from social.tests.backends.oauth import OAuth2Test

--- a/social/tests/backends/test_azuread.py
+++ b/social/tests/backends/test_azuread.py
@@ -1,6 +1,8 @@
 import json
 from social.p3 import urlencode
 from social.tests.backends.oauth import OAuth2Test
+from httpretty import HTTPretty
+from social.tests.models import User
 
 class AzureADOAuth2Test(OAuth2Test):
 
@@ -18,13 +20,16 @@ class AzureADOAuth2Test(OAuth2Test):
                     '4YjgxLTQzOGMtOGQ0ZS1hZDZmNTYyYjI4YmIiLCJ1cG4iOiJmb29iYXJAdGVzdC5vbm1pY3Jvc29mdC5jb20iLCJnaXZlbl9u'
                     'YW1lIjoiZm9vIiwiZmFtaWx5X25hbWUiOiJiYXIiLCJuYW1lIjoiZm9vIGJhciIsInVuaXF1ZV9uYW1lIjoiZm9vYmFyQHRlc'
                     '3Qub25taWNyb3NvZnQuY29tIiwicHdkX2V4cCI6IjQ3MzMwOTY4IiwicHdkX3VybCI6Imh0dHBzOi8vcG9ydGFsLm1pY3Jvc2'
-                    '9mdG9ubGluZS5jb20vQ2hhbmdlUGFzc3dvcmQuYXNweCJ9.3V50dHXTZOHj9UWtkn2g7BjX5JxNe8skYlK4PdhiLz4'
+                    '9mdG9ubGluZS5jb20vQ2hhbmdlUGFzc3dvcmQuYXNweCJ9.3V50dHXTZOHj9UWtkn2g7BjX5JxNe8skYlK4PdhiLz4',
+        'expires_in': 3600,
+        'expires_on': 1423650396,
+        'not_before': 1423646496
     })
 
     refresh_token_body = json.dumps({
         'access_token': 'foobar-new-token',
         'token_type': 'bearer',
-        'expires_in': 3600.0,
+        'expires_in': 3600,
         'refresh_token': 'foobar-new-refresh-token',
         'scope': 'identity'
     })
@@ -38,3 +43,16 @@ class AzureADOAuth2Test(OAuth2Test):
     def test_refresh_token(self):
         user, social = self.do_refresh_token()
         self.assertEqual(social.extra_data['access_token'], 'foobar-new-token')
+
+    # TODO:
+    # def test_get_access_token(self):
+        # self.do_login()
+        # HTTPretty.register_uri(self._method(self.backend.REFRESH_TOKEN_METHOD),
+                               # self.backend.REFRESH_TOKEN_URL or
+                               # self.backend.ACCESS_TOKEN_URL,
+                               # status=200,
+                               # body=self.refresh_token_body)
+        # user = list(User.cache.values())[0]
+        # token = self.backend.get_auth_token(user_id=user.id)
+        # self.assertEqual(token, 'foobar-new-token')
+        


### PR DESCRIPTION
This PR adds support for Azure Active Directory (OAuth2 protocol) to python-social-auth. Some test cases and documentation are also included, but if anything is missing or incorrect, please let us know.