### PR TITLE
Don't exclude egg-info.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ recursive-include social/tests *.txt
 graft examples
 
 recursive-exclude .tox *
-recursive-exclude python_social_auth.egg-info *
 recursive-exclude social *.pyc
 recursive-exclude examples *.pyc
 recursive-exclude examples *.db


### PR DESCRIPTION
Excluding `egg-info` in `MANIFEST.in` breaks buildout installation with the following error message:

```
No eggs found in /tmp/easy_install-I43eXo/python-social-auth-0.2.10/egg-dist-tmp-R1VwTo (setup script problem?)
```

Removing the exclude directive fixes the problem. 