### PR TITLE
Added an OAuth2 backend for Bitbucket

### DIFF
--- a/docs/backends/bitbucket.rst
+++ b/docs/backends/bitbucket.rst
@@ -1,26 +1,37 @@
 Bitbucket
 =========
 
-Bitbucket works similar to Twitter OAuth.
+Bitbucket supports both OAuth2 and OAuth1 logins.
 
-- Register a new application by emailing ``support@bitbucket.org`` with an
-  application name and a bit of a description,
+1. Register a new OAuth Consumer by following the instructions in the
+   Bitbucket documentation: `OAuth on Bitbucket`_
+
+   Note: For OAuth2, your consumer MUST have the "account" scope otherwise
+   the user profile information (username, name, etc.) won't be accessible.
+
+2. Configure the appropriate settings for OAuth2 or OAuth1 (see below).
+
+OAuth2
+------
 
 - Fill ``Consumer Key`` and ``Consumer Secret`` values in the settings::
 
-      SOCIAL_AUTH_BITBUCKET_KEY = ''
-      SOCIAL_AUTH_BITBUCKET_SECRET = ''
+    SOCIAL_AUTH_BITBUCKET_OAUTH2_KEY = '<your-consumer-key>'
+    SOCIAL_AUTH_BITBUCKET_OAUTH2_SECRET = '<your-consumer-secret>'
 
+- If you would like to restrict access to only users with verified e-mail
+  addresses, set ``SOCIAL_AUTH_BITBUCKET_OAUTH2_VERIFIED_EMAILS_ONLY = True``
 
+OAuth1
+------
 
-Settings
---------
+- OAuth1 works similarly to OAuth2, but you must fill in the following settings
+  instead::
 
-Sometimes Bitbucket users don't have a verified email address, making it
-impossible to get the basic user information to continue the auth process.
-It's possible to avoid these users with this setting::
+    SOCIAL_AUTH_BITBUCKET_KEY = '<your-consumer-key>'
+    SOCIAL_AUTH_BITBUCKET_SECRET = '<your-consumer-secret>'
 
-    SOCIAL_AUTH_BITBUCKET_VERIFIED_EMAILS_ONLY = True
+- If you would like to restrict access to only users with verified e-mail
+  addresses, set ``SOCIAL_AUTH_BITBUCKET_VERIFIED_EMAILS_ONLY = True``
 
-By default the setting is set to ``False`` since it's possible for a project to
-gather this information by other methods.
+.. _OAuth on Bitbucket: https://confluence.atlassian.com/display/BITBUCKET/OAuth+on+Bitbucket

--- a/social/backends/bitbucket.py
+++ b/social/backends/bitbucket.py
@@ -13,6 +13,10 @@ class BitbucketOAuth(BaseOAuth1):
     REQUEST_TOKEN_URL = 'https://bitbucket.org/api/1.0/oauth/request_token'
     ACCESS_TOKEN_URL = 'https://bitbucket.org/api/1.0/oauth/access_token'
 
+    # Bitbucket usernames can change. The account ID should always be the UUID
+    # See: https://confluence.atlassian.com/display/BITBUCKET/Use+the+Bitbucket+REST+APIs
+    ID_KEY = 'uuid'
+
     def get_user_details(self, response):
         """Return user details from Bitbucket account"""
         fullname, first_name, last_name = self.get_user_names(response['display_name'])

--- a/social/backends/bitbucket.py
+++ b/social/backends/bitbucket.py
@@ -9,51 +9,41 @@ from social.backends.oauth import BaseOAuth1
 class BitbucketOAuth(BaseOAuth1):
     """Bitbucket OAuth authentication backend"""
     name = 'bitbucket'
-    ID_KEY = 'username'
     AUTHORIZATION_URL = 'https://bitbucket.org/api/1.0/oauth/authenticate'
     REQUEST_TOKEN_URL = 'https://bitbucket.org/api/1.0/oauth/request_token'
     ACCESS_TOKEN_URL = 'https://bitbucket.org/api/1.0/oauth/access_token'
-    EXTRA_DATA = [
-        ('username', 'username'),
-        ('expires', 'expires'),
-        ('email', 'email'),
-        ('first_name', 'first_name'),
-        ('last_name', 'last_name')
-    ]
 
     def get_user_details(self, response):
         """Return user details from Bitbucket account"""
-        fullname, first_name, last_name = self.get_user_names(
-            first_name=response.get('first_name', ''),
-            last_name=response.get('last_name', '')
-        )
-        return {'username': response.get('username') or '',
-                'email': response.get('email') or '',
+        fullname, first_name, last_name = self.get_user_names(response['display_name'])
+
+        return {'username': response.get('username', ''),
+                'email': response.get('email', ''),
                 'fullname': fullname,
                 'first_name': first_name,
                 'last_name': last_name}
 
     def user_data(self, access_token):
         """Return user data provided"""
-        # Bitbucket has a bit of an indirect route to obtain user data from an
-        # authenticated query: First obtain the user's email via an
-        # authenticated GET, then retrieve the user's primary email address or
-        # the top email
-        emails = self.get_json('https://bitbucket.org/api/1.0/emails/',
+        emails = self.get_json('https://api.bitbucket.org/2.0/user/emails',
                                auth=self.oauth_auth(access_token))
+
         email = None
-        for address in reversed(emails):
-            if address['active']:
-                email = address['email']
-                if address['primary']:
-                    break
+
+        for address in reversed(emails['values']):
+            email = address['email']
+            if address['is_primary']:
+                break
+
+        if self.setting('VERIFIED_EMAILS_ONLY', False) and not address['is_confirmed']:
+            raise AuthForbidden(
+                self, 'Bitbucket account has no verified email'
+            )
+
+        user = self.get_json('https://api.bitbucket.org/2.0/user',
+                             auth=self.oauth_auth(access_token))
 
         if email:
-            return dict(self.get_json('https://bitbucket.org/api/1.0/users/' +
-                                      email)['user'],
-                        email=email)
-        elif self.setting('VERIFIED_EMAILS_ONLY', False):
-            raise AuthForbidden(self,
-                                'Bitbucket account has any verified email')
-        else:
-            return {}
+            user['email'] = email
+
+        return user

--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -350,6 +350,9 @@ class BaseOAuth2(OAuthAuth):
             'redirect_uri': self.get_redirect_uri(state)
         }
 
+    def auth_complete_credentials(self):
+        return None
+
     def auth_headers(self):
         return {'Content-Type': 'application/x-www-form-urlencoded',
                 'Accept': 'application/json'}
@@ -371,12 +374,15 @@ class BaseOAuth2(OAuthAuth):
         """Completes loging process, must return user instance"""
         state = self.validate_state()
         self.process_error(self.data)
+
         response = self.request_access_token(
             self.access_token_url(),
             data=self.auth_complete_params(state),
             headers=self.auth_headers(),
+            auth=self.auth_complete_credentials(),
             method=self.ACCESS_TOKEN_METHOD
         )
+        print(dict(response))
         self.process_error(response)
         return self.do_auth(response['access_token'], response=response,
                             *args, **kwargs)
@@ -384,6 +390,8 @@ class BaseOAuth2(OAuthAuth):
     @handle_http_errors
     def do_auth(self, access_token, *args, **kwargs):
         """Finish the auth process once the access_token was retrieved"""
+        print(args)
+        print(kwargs)
         data = self.user_data(access_token, *args, **kwargs)
         response = kwargs.get('response') or {}
         response.update(data or {})

--- a/social/tests/backends/test_bitbucket.py
+++ b/social/tests/backends/test_bitbucket.py
@@ -9,7 +9,7 @@ from social.tests.backends.oauth import OAuth1Test
 
 class BitbucketOAuth1Test(OAuth1Test):
     backend_path = 'social.backends.bitbucket.BitbucketOAuth'
-    user_data_url = 'https://bitbucket.org/api/1.0/users/foo@bar.com'
+    user_data_url = 'https://api.bitbucket.org/2.0/user'
     expected_username = 'foobar'
     access_token_body = json.dumps({
         'access_token': 'foobar',
@@ -20,46 +20,73 @@ class BitbucketOAuth1Test(OAuth1Test):
         'oauth_token': 'foobar',
         'oauth_callback_confirmed': 'true'
     })
-    emails_body = json.dumps([{
-        'active': True,
-        'email': 'foo@bar.com',
-        'primary': True
-    }])
+    emails_body = json.dumps({
+        u'page': 1,
+        u'pagelen': 10,
+        u'size': 2,
+        u'values': [
+            {
+                u'email': u'foo@bar.com',
+                u'is_confirmed': True,
+                u'is_primary': True,
+                u'links': { u'self': {u'href': u'https://api.bitbucket.org/2.0/user/emails/foo@bar.com'}},
+                u'type': u'email'
+            },
+            {
+                u'email': u'not@confirme.com',
+                u'is_confirmed': False,
+                u'is_primary': False,
+                u'links': {u'self': {u'href': u'https://api.bitbucket.org/2.0/user/emails/not@confirmed.com'}},
+                u'type': u'email'
+            }
+        ]
+    })
     user_data_body = json.dumps({
-        'user': {
-            'username': 'foobar',
-            'first_name': 'Foo',
-            'last_name': 'Bar',
-            'display_name': 'Foo Bar',
-            'is_team': False,
-            'avatar': 'https://secure.gravatar.com/avatar/'
-                      '5280f15cedf540b544eecc30fcf3027c?'
-                      'd=https%3A%2F%2Fd3oaxc4q5k2d6q.cloudfront.net%2Fm%2F'
-                      '9e262ba34f96%2Fimg%2Fdefault_avatar%2F32%2F'
-                      'user_blue.png&s=32',
-            'resource_uri': '/1.0/users/foobar'
-        }
+        u'created_on': u'2012-03-29T18:07:38+00:00',
+        u'display_name': u'Foo Bar',
+        u'links': {
+            u'avatar': {u'href': u'https://bitbucket.org/account/foobar/avatar/32/'},
+            u'followers': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/followers'},
+            u'following': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/following'},
+            u'hooks': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/hooks'},
+            u'html': {u'href': u'https://bitbucket.org/foobar'},
+            u'repositories': {u'href': u'https://api.bitbucket.org/2.0/repositories/foobar'},
+            u'self': {u'href': u'https://api.bitbucket.org/2.0/users/foobar'}},
+        u'location': u'Fooville, Bar',
+        u'type': u'user',
+        u'username': u'foobar',
+        u'uuid': u'{397621dc-0f78-329f-8d6d-727396248e3f}',
+        u'website': u'http://foobar.com'
     })
 
     def test_login(self):
         HTTPretty.register_uri(HTTPretty.GET,
-                               'https://bitbucket.org/api/1.0/emails/',
+                               'https://api.bitbucket.org/2.0/user/emails',
                                status=200, body=self.emails_body)
         self.do_login()
 
     def test_partial_pipeline(self):
         HTTPretty.register_uri(HTTPretty.GET,
-                               'https://bitbucket.org/api/1.0/emails/',
+                               'https://api.bitbucket.org/2.0/user/emails',
                                status=200, body=self.emails_body)
         self.do_partial_pipeline()
 
 
 class BitbucketOAuth1FailTest(BitbucketOAuth1Test):
-    emails_body = json.dumps([{
-        'active': False,
-        'email': 'foo@bar.com',
-        'primary': True
-    }])
+    emails_body = json.dumps({
+        u'page': 1,
+        u'pagelen': 10,
+        u'size': 1,
+        u'values': [
+            {
+                u'email': u'foo@bar.com',
+                u'is_confirmed': False,
+                u'is_primary': True,
+                u'links': { u'self': {u'href': u'https://api.bitbucket.org/2.0/user/emails/foo@bar.com'}},
+                u'type': u'email'
+            }
+        ]
+    })
 
     def test_login(self):
         self.strategy.set_settings({

--- a/social/tests/backends/test_bitbucket.py
+++ b/social/tests/backends/test_bitbucket.py
@@ -4,22 +4,32 @@ from httpretty import HTTPretty
 
 from social.p3 import urlencode
 from social.exceptions import AuthForbidden
-from social.tests.backends.oauth import OAuth1Test
+from social.tests.backends.oauth import OAuth1Test, OAuth2Test
 
 
-class BitbucketOAuth1Test(OAuth1Test):
-    backend_path = 'social.backends.bitbucket.BitbucketOAuth'
+class BitbucketOAuthMixin(object):
     user_data_url = 'https://api.bitbucket.org/2.0/user'
     expected_username = 'foobar'
-    access_token_body = json.dumps({
-        'access_token': 'foobar',
-        'token_type': 'bearer'
+    bb_api_user_emails = 'https://api.bitbucket.org/2.0/user/emails'
+
+    user_data_body = json.dumps({
+        u'created_on': u'2012-03-29T18:07:38+00:00',
+        u'display_name': u'Foo Bar',
+        u'links': {
+            u'avatar': {u'href': u'https://bitbucket.org/account/foobar/avatar/32/'},
+            u'followers': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/followers'},
+            u'following': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/following'},
+            u'hooks': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/hooks'},
+            u'html': {u'href': u'https://bitbucket.org/foobar'},
+            u'repositories': {u'href': u'https://api.bitbucket.org/2.0/repositories/foobar'},
+            u'self': {u'href': u'https://api.bitbucket.org/2.0/users/foobar'}},
+        u'location': u'Fooville, Bar',
+        u'type': u'user',
+        u'username': u'foobar',
+        u'uuid': u'{397621dc-0f78-329f-8d6d-727396248e3f}',
+        u'website': u'http://foobar.com'
     })
-    request_token_body = urlencode({
-        'oauth_token_secret': 'foobar-secret',
-        'oauth_token': 'foobar',
-        'oauth_callback_confirmed': 'true'
-    })
+
     emails_body = json.dumps({
         u'page': 1,
         u'pagelen': 10,
@@ -41,33 +51,31 @@ class BitbucketOAuth1Test(OAuth1Test):
             }
         ]
     })
-    user_data_body = json.dumps({
-        u'created_on': u'2012-03-29T18:07:38+00:00',
-        u'display_name': u'Foo Bar',
-        u'links': {
-            u'avatar': {u'href': u'https://bitbucket.org/account/foobar/avatar/32/'},
-            u'followers': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/followers'},
-            u'following': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/following'},
-            u'hooks': {u'href': u'https://api.bitbucket.org/2.0/users/foobar/hooks'},
-            u'html': {u'href': u'https://bitbucket.org/foobar'},
-            u'repositories': {u'href': u'https://api.bitbucket.org/2.0/repositories/foobar'},
-            u'self': {u'href': u'https://api.bitbucket.org/2.0/users/foobar'}},
-        u'location': u'Fooville, Bar',
-        u'type': u'user',
-        u'username': u'foobar',
-        u'uuid': u'{397621dc-0f78-329f-8d6d-727396248e3f}',
-        u'website': u'http://foobar.com'
+
+
+class BitbucketOAuth1Test(BitbucketOAuthMixin, OAuth1Test):
+    backend_path = 'social.backends.bitbucket.BitbucketOAuth'
+
+    request_token_body = urlencode({
+        'oauth_token_secret': 'foobar-secret',
+        'oauth_token': 'foobar',
+        'oauth_callback_confirmed': 'true'
+    })
+
+    access_token_body = json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer'
     })
 
     def test_login(self):
         HTTPretty.register_uri(HTTPretty.GET,
-                               'https://api.bitbucket.org/2.0/user/emails',
+                               self.bb_api_user_emails,
                                status=200, body=self.emails_body)
         self.do_login()
 
     def test_partial_pipeline(self):
         HTTPretty.register_uri(HTTPretty.GET,
-                               'https://api.bitbucket.org/2.0/user/emails',
+                               self.bb_api_user_emails,
                                status=200, body=self.emails_body)
         self.do_partial_pipeline()
 
@@ -101,3 +109,58 @@ class BitbucketOAuth1FailTest(BitbucketOAuth1Test):
         })
         with self.assertRaises(AuthForbidden):
             super(BitbucketOAuth1FailTest, self).test_partial_pipeline()
+
+
+class BitbucketOAuth2Test(BitbucketOAuthMixin, OAuth2Test):
+    backend_path = 'social.backends.bitbucket.BitbucketOAuth2'
+
+    access_token_body = json.dumps({
+        'access_token': 'foobar_access',
+        'scopes': 'foo_scope',
+        'expires_in': 3600,
+        'refresh_token': 'foobar_refresh',
+        'token_type': 'bearer'
+    })
+
+    def test_login(self):
+        HTTPretty.register_uri(HTTPretty.GET,
+                               self.bb_api_user_emails,
+                               status=200, body=self.emails_body)
+        self.do_login()
+
+    def test_partial_pipeline(self):
+        HTTPretty.register_uri(HTTPretty.GET,
+                               self.bb_api_user_emails,
+                               status=200, body=self.emails_body)
+        self.do_partial_pipeline()
+
+
+class BitbucketOAuth2FailTest(BitbucketOAuth2Test):
+    emails_body = json.dumps({
+        u'page': 1,
+        u'pagelen': 10,
+        u'size': 1,
+        u'values': [
+            {
+                u'email': u'foo@bar.com',
+                u'is_confirmed': False,
+                u'is_primary': True,
+                u'links': { u'self': {u'href': u'https://api.bitbucket.org/2.0/user/emails/foo@bar.com'}},
+                u'type': u'email'
+            }
+        ]
+    })
+
+    def test_login(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_BITBUCKET_OAUTH2_VERIFIED_EMAILS_ONLY': True
+        })
+        with self.assertRaises(AuthForbidden):
+            super(BitbucketOAuth2FailTest, self).test_login()
+
+    def test_partial_pipeline(self):
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_BITBUCKET_OAUTH2_VERIFIED_EMAILS_ONLY': True
+        })
+        with self.assertRaises(AuthForbidden):
+            super(BitbucketOAuth2FailTest, self).test_partial_pipeline()


### PR DESCRIPTION
Bitbucket launched OAuth2 support a few weeks back. This PR adds an OAuth2 backend to python-social-auth and updates the documentation accordingly.

This PR is inclusive of #652. The diff will probably be a little bit clearer once it is merged in. 