### PR TITLE
Use official python-saml 2.1.3 release, remove now-unsupported setting

### DIFF
--- a/docs/backends/saml.rst
+++ b/docs/backends/saml.rst
@@ -10,6 +10,11 @@ users can use for authentication. For example, if your users are students, you
 could enable Harvard and MIT as identity providers, so that students of either
 of those two universities can use their campus login to access your app.
 
+Required Dependency
+-------------------
+
+You must install python-saml_ 2.1.3 or higher in order to use this backend.
+
 Required Configuration
 ----------------------
 
@@ -139,14 +144,6 @@ Advanced Settings
   your metadata for up to 10 days, but no longer. ``metadataCacheDuration`` must
   be specified as an ISO 8601 duration string (e.g. `P1D` for one day).
 
-- ``SOCIAL_AUTH_SAML_SP_NAMEID_FORMATS``: This is a list of ``NameID`` formats
-  accepted by your app. The default is not to specify any. Example::
-
-      SOCIAL_AUTH_SAML_SP_NAMEID_FORMATS = [
-        'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-        'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
-      ]
-
 
 Advanced Usage
 --------------
@@ -167,5 +164,6 @@ particular, there are two methods that are designed for subclasses to override:
   inspecting the passed attributes parameter, do nothing to allow the user to
   login, or raise ``social.exceptions.AuthForbidden`` to reject the user.
 
+.. _python-saml: https://github.com/onelogin/python-saml
 .. _TestShib: https://www.testshib.org/
 .. _metadata: https://www.testshib.org/metadata/testshib-providers.xml

--- a/social/backends/saml.py
+++ b/social/backends/saml.py
@@ -167,7 +167,6 @@ class SAMLAuth(BaseAuth):
     Optional settings:
     SOCIAL_AUTH_SAML_SP_EXTRA = {}
     SOCIAL_AUTH_SAML_SECURITY_CONFIG = {}
-    SOCIAL_AUTH_SAML_SP_NAMEID_FORMATS = []
     """
     name = "saml"
 
@@ -202,7 +201,6 @@ class SAMLAuth(BaseAuth):
                     'binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
                 },
                 'entityId': self.setting('SP_ENTITY_ID'),
-                'NameIDFormats': self.setting('SP_NAMEID_FORMATS', []),
                 'x509cert': self.setting('SP_PUBLIC_CERT'),
                 'privateKey': self.setting('SP_PRIVATE_KEY'),
             },

--- a/social/tests/requirements.txt
+++ b/social/tests/requirements.txt
@@ -6,4 +6,4 @@ rednose>=0.4.1
 requests>=1.1.0
 PyJWT>=1.0.0,<2.0.0
 unittest2==0.5.1
-git+https://github.com/open-craft/python-saml.git@9602b8133056d8c3caa7c3038761147df3d4b257#egg=python-saml
+python-saml==2.1.3


### PR DESCRIPTION
The SAML backend can now use the latest official release of python-saml, rather than a fork, since the release now includes the required changes. Version 2.1.3 is largely the same as the commit hash previously specified, with one notable difference being that the "NameIDFormats" setting change that I had proposed was rejected in favor of [a simpler fix](https://github.com/onelogin/python-saml/commit/3a5847be93fd7e3af695d791989825cc6c118808) that should meet the same goals.

So, this PR:
* Uses the official release of python-saml instead of the fork
* Removes the now-unsupported `NameIDFormats` setting, which was unlikely to be needed by most people anyways. Those who do need to override the `NameIDFormat` can configure it using the `SOCIAL_AUTH_SAML_SP_EXTRA` dict, but that is unlikely to be a common requirement.
* Updates the documentation accordingly