### PR TITLE
Fix cookie handling for tornado

### DIFF
--- a/social/strategies/tornado_strategy.py
+++ b/social/strategies/tornado_strategy.py
@@ -41,14 +41,17 @@ class TornadoStrategy(BaseStrategy):
         self.request_handler.write(content)
 
     def session_get(self, name, default=None):
-        return self.request_handler.get_secure_cookie(name) or default
+        value = self.request_handler.get_secure_cookie(name)
+        if value:
+            return json.loads(value.decode())
+        return default
 
     def session_set(self, name, value):
-        self.request_handler.set_secure_cookie(name, str(value))
+        self.request_handler.set_secure_cookie(name, json.dumps(value).encode())
 
     def session_pop(self, name):
-        value = self.request_handler.get_secure_cookie(name)
-        self.request_handler.set_secure_cookie(name, '')
+        value = self.session_get(name)
+        self.request_handler.clear_cookie(name)
         return value
 
     def session_setdefault(self, name, value):


### PR DESCRIPTION
The strategy is expected to store lists and other structures in session, but tornado's cookies only store bytes. This fixes that by encoding it to json.
