### PR TITLE
PR fix `user_details` pipeline issue

### DIFF
--- a/social/pipeline/user.py
+++ b/social/pipeline/user.py
@@ -85,7 +85,7 @@ def user_details(strategy, details, user=None, *args, **kwargs):
         for name, value in details.items():
             if value and hasattr(user, name):
                 current_value = getattr(user, name, None)
-                if current_value is None or name not in protected:
+                if not current_value or name not in protected:
                     changed |= current_value != value
                     setattr(user, name, value)
 


### PR DESCRIPTION
@omab 
Fix in this PR is changing `current_value` checking to allow to change empty and protected user fields.
Issue described in [ISSUE#671](https://github.com/omab/python-social-auth/issues/671).
Plz review this PR.
Thanks.