### PR TITLE
Fix redirect_uri issue with tornado reversed url

### DIFF
--- a/social/apps/tornado_app/routes.py
+++ b/social/apps/tornado_app/routes.py
@@ -5,7 +5,7 @@ from .handlers import AuthHandler, CompleteHandler, DisconnectHandler
 
 SOCIAL_AUTH_ROUTES = [
     url(r'/login/(?P<backend>[^/]+)/?', AuthHandler, name='begin'),
-    url(r'/complete/(?P<backend>[^/]+)/?', CompleteHandler, name='complete'),
+    url(r'/complete/(?P<backend>[^/]+)/', CompleteHandler, name='complete'),
     url(r'/disconnect/(?P<backend>[^/]+)/?', DisconnectHandler,
         name='disconnect'),
     url(r'/disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/?',


### PR DESCRIPTION
When reversing URLs, tornado doesn't interpret the regex optional symbol '?'. This causes the redirect_uri to be https://example.com/complete/mybackend/? with the question mark appended. Some providers will simply append to this uri, causing URLs like https://example.com/complete/mybackend/??code=.... with two question marks. This makes the interpretation of the query string fail.

The provider in this case is [django-oidc-provider](https://github.com/juanifioren/django-oidc-provider). Arguably that library should be smarter in constructing the redirection, but removing the question mark from the uri solves these kind of issues.

Alternatively we could strip the question mark from the uri in the tornado strategy in [here](https://github.com/omab/python-social-auth/blob/470a597f7d5dbb189b72e25cdc0fc2f360435d39/social/strategies/tornado_strategy.py#L61-L64), but this seemed simpler.