### PR TITLE
Close #622 by explicitly setting email length (compatibility with Django 1.7)

### DIFF
--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -89,7 +89,7 @@ class Association(models.Model, DjangoAssociationMixin):
 
 
 class Code(models.Model, DjangoCodeMixin):
-    email = models.EmailField()
+    email = models.EmailField(max_length=254)
     code = models.CharField(max_length=32, db_index=True)
     verified = models.BooleanField(default=False)
 


### PR DESCRIPTION
Django 1.8 increases default max_length of EmailField from 75 to 254. Since max_length is not currently specified, but the initial migration contains the 1.8 default of 254, Django 1.7 will think there's a migration to create, decreasing the max_length to 75. This can be fixed by explicitly setting the max_length to 254.