### PR TITLE
text -> content solves "is not JSON serializable"

### DIFF
--- a/social/backends/linkedin.py
+++ b/social/backends/linkedin.py
@@ -68,7 +68,7 @@ class LinkedinOAuth(BaseLinkedinAuth, BaseOAuth1):
             scope = '?scope=' + self.SCOPE_SEPARATOR.join(scope)
         return self.request(self.REQUEST_TOKEN_URL + scope,
                             params=self.request_token_extra_arguments(),
-                            auth=self.oauth_auth()).content
+                            auth=self.oauth_auth()).text
 
 
 class LinkedinOAuth2(BaseLinkedinAuth, BaseOAuth2):


### PR DESCRIPTION
Right now when you use .content, the token is bytes, not text, and so you run into an error when saving it to the session. Similar error in issue #139.