### PR TITLE
support for goclio.eu service

### DIFF
--- a/social/backends/goclioeu.py
+++ b/social/backends/goclioeu.py
@@ -1,0 +1,14 @@
+from social.backends.goclio import GoClioOAuth2
+
+
+class GoClioEuOAuth2(GoClioOAuth2):
+    name = 'goclioeu'
+    AUTHORIZATION_URL = 'https://app.goclio.eu/oauth/authorize/'
+    ACCESS_TOKEN_URL = 'https://app.goclio.eu/oauth/token/'
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Loads user data from service"""
+        return self.get_json(
+            'https://app.goclio.eu/api/v2/users/who_am_i',
+            params={'access_token': access_token}
+        )


### PR DESCRIPTION
Add support for goclio's european servers. goclio.eu is pratically the same as goclio.com, but it has a different app registry, so you have different (key, secret) pairs for each domain and different domains on the API calls.