### PR TITLE
Send correct nonce in OIDC id_token

### DIFF
--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -291,14 +291,6 @@ class OpenIdConnectAuth(BaseOAuth2):
         )
         return params
 
-    def auth_complete_params(self, state=None):
-        params = super(OpenIdConnectAuth, self).auth_complete_params(state)
-        # Add a nonce to the request so that to help counter CSRF
-        params['nonce'] = self.get_and_store_nonce(
-            self.ACCESS_TOKEN_URL, state
-        )
-        return params
-
     def get_and_store_nonce(self, url, state):
         # Create a nonce
         nonce = self.strategy.random_string(64)
@@ -310,7 +302,7 @@ class OpenIdConnectAuth(BaseOAuth2):
     def get_nonce(self, nonce):
         try:
             return self.strategy.storage.association.get(
-                server_url=self.ACCESS_TOKEN_URL,
+                server_url=self.AUTHORIZATION_URL,
                 handle=nonce
             )[0]
         except IndexError:

--- a/social/tests/backends/oauth.py
+++ b/social/tests/backends/oauth.py
@@ -76,6 +76,8 @@ class BaseOAuthTest(BaseBackendTest):
         response = requests.get(start_url)
         self.assertEqual(response.url, target_url)
         self.assertEqual(response.text, 'foobar')
+        self.strategy.set_request_data(parse_qs(urlparse(start_url).query),
+                                       self.backend)
         self.strategy.set_request_data(parse_qs(urlparse(target_url).query),
                                        self.backend)
         return self.backend.complete()

--- a/social/tests/backends/open_id.py
+++ b/social/tests/backends/open_id.py
@@ -143,7 +143,7 @@ class OpenIdConnectTestMixin(object):
         Get the nonce from the request parameters, add it to the id_token, and
         return the complete response.
         """
-        nonce = parse_qs(request.body).get('nonce')
+        nonce = self.backend.data['nonce']
         body = self.prepare_access_token_body(nonce=nonce)
         return 200, headers, body
 


### PR DESCRIPTION
The token should contain the nonce from the authentication request, not from the token request. I'm not sure how this could have worked, but https://github.com/omab/python-social-auth/issues/477 and https://github.com/omab/python-social-auth/issues/644 seem related.