### PR TITLE
removed @app.teardown_request since it is called before @app.teardown…

### DIFF
--- a/examples/flask_example/__init__.py
+++ b/examples/flask_example/__init__.py
@@ -55,10 +55,9 @@ def global_user():
 def commit_on_success(error=None):
     if error is None:
         db_session.commit()
+    else:
+        db_session.rollback()
 
-
-@app.teardown_request
-def shutdown_session(exception=None):
     db_session.remove()
 
 


### PR DESCRIPTION
removed @app.teardown_request since it is called before @app.teardown_appcontext and clears current session.

With @app.teardown_request session is removed just before session.commit and logged in user can not be saved on db.

Added session.rollback in case of error and session remove to remove thread local session storage.