### PR TITLE
Make an abstract verstion of django's UserSocialAuth's model so it can be extended (fixes #698)

### DIFF
--- a/social/apps/django_app/default/managers.py
+++ b/social/apps/django_app/default/managers.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+
+class UserSocialAuthManager(models.Manager):
+    """Manager for the UserSocialAuth django model."""
+
+    def get_social_auth(self, provider, uid):
+        try:
+            return self.select_related('user').get(provider=provider,
+                                                   uid=uid)
+        except self.model.DoesNotExist:
+            return None


### PR DESCRIPTION
The details of this PR are laid out in #698.  The two things this PR does:

1. Create an abstract class for the django ``UserSocialAuth`` model so it can be extended
1. Adds an object manager to the ``UserSocialAuth`` class which is the "django way" of performing actions that the class method ``get_social_auth(cls, provider, uid)`` is trying to do.  (``UserSocialAuth.get_social_auth(...)`` should now be deprecated in favor of ``UserSocialAuth.objects.get_social_auth(...)``)

Fixes #698