### PR TITLE
Add REDIRECT_STATE = False

### DIFF
--- a/social/backends/shopify.py
+++ b/social/backends/shopify.py
@@ -19,6 +19,7 @@ class ShopifyOAuth2(BaseOAuth2):
         ('website', 'website'),
         ('expires', 'expires')
     ]
+    REDIRECT_STATE = False
 
     @property
     def shopifyAPI(self):


### PR DESCRIPTION
To use Shopify's `Redirection URL` settings, redirect state should not be appended.