### PR TITLE
VK API workflow fix if error happens on vk-side

### DIFF
--- a/social/backends/vk.py
+++ b/social/backends/vk.py
@@ -111,7 +111,7 @@ class VKOAuth2(BaseOAuth2):
             'fields': fields,
         })
 
-        if data.get('error'):
+        if data and data.get('error'):
             error = data['error']
             msg = error.get('error_msg', 'Unknown error')
             if error.get('error_code') == 5:
@@ -122,7 +122,7 @@ class VKOAuth2(BaseOAuth2):
         if data:
             data = data.get('response')[0]
             data['user_photo'] = data.get('photo')  # Backward compatibility
-        return data
+        return data or {}
 
 
 class VKAppOAuth2(VKOAuth2):


### PR DESCRIPTION
Sometime vk_api function returns None (when vk.com is down for example) but user_data expects dict and fails.