### PR TITLE
Instagram: Support signed requests

### DIFF
--- a/social/backends/instagram.py
+++ b/social/backends/instagram.py
@@ -38,7 +38,7 @@ class InstagramOAuth2(BaseOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
         key, secret = self.get_key_and_secret()
-        params = params={'access_token': access_token}
+        params = {'access_token': access_token}
         sig = self._generate_sig("users/self", params, secret)
         params['sig'] = sig
         return self.get_json('https://api.instagram.com/v1/users/self',

--- a/social/backends/instagram.py
+++ b/social/backends/instagram.py
@@ -39,7 +39,7 @@ class InstagramOAuth2(BaseOAuth2):
         """Loads user data from service"""
         key, secret = self.get_key_and_secret()
         params = {'access_token': access_token}
-        sig = self._generate_sig("users/self", params, secret)
+        sig = self._generate_sig("/users/self", params, secret)
         params['sig'] = sig
         return self.get_json('https://api.instagram.com/v1/users/self',
                              params=params)

--- a/social/backends/instagram.py
+++ b/social/backends/instagram.py
@@ -42,7 +42,7 @@ class InstagramOAuth2(BaseOAuth2):
         sig = self._generate_sig("users/self", params, secret)
         params['sig'] = sig
         return self.get_json('https://api.instagram.com/v1/users/self',
-                             params)
+                             params=params)
 
     def _generate_sig(self, endpoint, params, secret):
         sig = endpoint


### PR DESCRIPTION
Added `sig` parameter to API call so that this library still works when one enables *Enforce signed requests* setting in Instagram backend.