### PR TITLE
Django Strategy: support for X-Forwarded-* headers 

### DIFF
--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -51,6 +51,11 @@ class DjangoStrategy(BaseStrategy):
 
     def request_host(self):
         if self.request:
+            if self.setting("RESPECT_X_FORWARDED_HEADERS", False):
+                forwarded_host = self.request.META.get('HTTP_X_FORWARDED_HOST')
+                if forwarded_host:
+                    return forwarded_host
+
             return self.request.get_host()
 
     def request_is_secure(self):
@@ -63,6 +68,11 @@ class DjangoStrategy(BaseStrategy):
 
     def request_port(self):
         """Port in use for this request"""
+        if self.setting("RESPECT_X_FORWARDED_HEADERS", False):
+            forwarded_port = self.request.META.get('HTTP_X_FORWARDED_PORT')
+            if forwarded_port:
+                return forwarded_port
+
         return self.request.META['SERVER_PORT']
 
     def request_get(self):


### PR DESCRIPTION
**Description:** This PR adds support for getting host and port from X-Forwarded-* headers, if they are available.

**Related:** https://github.com/edx-solutions/edx-platform/pull/530, https://github.com/edx/edx-platform/pull/9848

**Motivation:** If an application using PSA is running behind the reverse proxy on a non-standard port, PSA (python-saml, to be precise) fails checking the SAML assertion response with message "Authentication failed: SAML login failed: ['invalid_response'] The response was received at http://host:port instead of http://host".

Common way of passing original host and port to proxied app is using X-Forwarded-* headers. Some webservers (i.e. gunicorn) already respect those headers and pass them to django as "real" host and port (i.e. `request.get_host()` and `request.META['SERVER_PORT']` actually return X-Forwarded-Host and X-Forwarded-Port` values). Other webservers (i.e. django dev server, nginx(?)) does not do so.

This PR adds a web-server-agnostic way to use PSA behind the reverse proxy.

**Author concerns:**
1. This might not be an optimal way to do it. Possible alternatives:
1.1. It is already working fine; clients should either use web-servers that respect X-Forwarded-* headers, or solve this issue in some other, non-PSA-related way.
1.2. Clients should provide custom strategy with `request-host` and `request_port` overridden (i.e. follow the same approach as in https://github.com/edx/edx-platform/pull/9848)
2. There seems to be serious complications to testing frameworks-specific code - there're no tests for framework-specific strategies so far, and adding a test for django strategy required adding Django, specifying settings and so on - and eventually blowed up entire test suite. Hence tests are not included so far, but I would be glad to add them, if some architectural guidance is given.