### PR TITLE
Save extra_data on login

### DIFF
--- a/social/storage/sqlalchemy_orm.py
+++ b/social/storage/sqlalchemy_orm.py
@@ -12,6 +12,7 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.types import PickleType, Text
 from sqlalchemy.schema import UniqueConstraint
+from sqlalchemy.ext.mutable import MutableDict
 
 from social.storage.base import UserMixin, AssociationMixin, NonceMixin, \
                                 CodeMixin, BaseStorage
@@ -66,7 +67,7 @@ class SQLAlchemyUserMixin(SQLAlchemyMixin, UserMixin):
     __table_args__ = (UniqueConstraint('provider', 'uid'),)
     id = Column(Integer, primary_key=True)
     provider = Column(String(32))
-    extra_data = Column(JSONType)
+    extra_data = Column(MutableDict.as_mutable(JSONType))
     uid = None
     user_id = None
     user = None


### PR DESCRIPTION
SQLAlchemy can't detect changes to the extra_data property of a user. By wrapping in a MutableDict it can and will save updated data (like bearer tokens in case of OAuth).