### PR TITLE
Store all tokens when tokens are refreshed

### DIFF
--- a/social/storage/base.py
+++ b/social/storage/base.py
@@ -52,14 +52,7 @@ class UserMixin(object):
         if token and backend and hasattr(backend, 'refresh_token'):
             backend = backend(strategy=strategy)
             response = backend.refresh_token(token, *args, **kwargs)
-            access_token = response.get('access_token')
-            refresh_token = response.get('refresh_token')
-
-            if access_token or refresh_token:
-                if access_token:
-                    self.extra_data['access_token'] = access_token
-                if refresh_token:
-                    self.extra_data['refresh_token'] = refresh_token
+            if self.set_extra_data(response):
                 self.save()
 
     def expiration_datetime(self):


### PR DESCRIPTION
Some backends (e.g. OpenIdConnect) have an `id_token` next to an `access_token` and `refresh_token`, so they all need to be stored.