### PR TITLE
Fix vk backend

### DIFF
--- a/social/backends/vk.py
+++ b/social/backends/vk.py
@@ -85,9 +85,6 @@ class VKOAuth2(BaseOAuth2):
         ('expires_in', 'expires')
     ]
 
-    def get_user_id(self, details, response):
-        return response['uid']
-
     def get_user_details(self, response):
         """Return user details from VK.com account"""
         fullname, first_name, last_name = self.get_user_names(


### PR DESCRIPTION
Fix get_user_id method for modern VK API response (5.34 tested) where no uid param - fallback to get_user_id from BaseAuth class which gets uid by self.ID_KEY