### PR TITLE
Fix RemovedInDjango19Warning warnings

### DIFF
--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -69,6 +69,7 @@ class UserSocialAuth(AbstractUserSocialAuth):
 
     class Meta:
         """Meta data"""
+        app_label = 'default'
         unique_together = ('provider', 'uid')
         db_table = 'social_auth_usersocialauth'
 
@@ -80,6 +81,7 @@ class Nonce(models.Model, DjangoNonceMixin):
     salt = models.CharField(max_length=65)
 
     class Meta:
+        app_label = 'default'
         unique_together = ('server_url', 'timestamp', 'salt')
         db_table = 'social_auth_nonce'
 
@@ -94,6 +96,7 @@ class Association(models.Model, DjangoAssociationMixin):
     assoc_type = models.CharField(max_length=64)
 
     class Meta:
+        app_label = 'default'
         db_table = 'social_auth_association'
 
 
@@ -103,6 +106,7 @@ class Code(models.Model, DjangoCodeMixin):
     verified = models.BooleanField(default=False)
 
     class Meta:
+        app_label = 'default'
         db_table = 'social_auth_code'
         unique_together = ('email', 'code')
 


### PR DESCRIPTION
These changes will remove warnings like below

```
RemovedInDjango19Warning: Model class social.apps.django_app.default.models.Code 
doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS
or else was imported before its application was loaded. This will no longer be supported
in Django 1.9.
```