### PR TITLE
decode b64 result back to unicode before str interp

### DIFF
--- a/social/backends/reddit.py
+++ b/social/backends/reddit.py
@@ -44,7 +44,7 @@ class RedditOAuth2(BaseOAuth2):
         return {
             'Authorization': 'Basic {0}'.format(base64.urlsafe_b64encode(
                 ('{0}:{1}'.format(*self.get_key_and_secret()).encode())
-            ))
+            ).decode())
         }
 
     def refresh_token_params(self, token, redirect_uri=None, *args, **kwargs):

--- a/social/tests/backends/test_reddit.py
+++ b/social/tests/backends/test_reddit.py
@@ -1,6 +1,8 @@
 import json
 
+from unittest import TestCase
 from social.tests.backends.oauth import OAuth2Test
+from social.backends.reddit import RedditOAuth2
 
 
 class RedditOAuth2Test(OAuth2Test):
@@ -57,3 +59,13 @@ class RedditOAuth2Test(OAuth2Test):
     def test_refresh_token(self):
         user, social = self.do_refresh_token()
         self.assertEqual(social.extra_data['access_token'], 'foobar-new-token')
+
+
+class RedditOAuth2Test(TestCase):
+
+    def setUp(self):
+        self.backend = RedditOAuth2()
+        self.backend.setting = { "KEY": "k", "SECRET": "s" }.get
+
+    def test_auth_headers(self):
+        self.assertEqual({'Authorization': 'Basic azpz'}, self.backend.auth_headers())


### PR DESCRIPTION
In #440, we learn the reddit authorization string that composes key and
secret into a base-64 string leaves it as a bytestring, and then tries
in python3 tries to insert it into a unicode literal.  That adds its
repr format "b'foo'" in the auth, which is wrong.

Instead encode the base64 string back to unicode. The b64 format is
guaranteed to be 7-bit safe, so even lame default encodings should
handle it fine.
