### PR TITLE
Formatter fixes for SAML to support Py2.6

### DIFF
--- a/social/backends/saml.py
+++ b/social/backends/saml.py
@@ -278,7 +278,7 @@ class SAMLAuth(BaseAuth):
         """
         idp = self.get_idp(response['idp_name'])
         uid = idp.get_user_permanent_id(response['attributes'])
-        return '{}:{}'.format(idp.name, uid)
+        return '{0}:{1}'.format(idp.name, uid)
 
     def auth_complete(self, *args, **kwargs):
         """
@@ -293,7 +293,7 @@ class SAMLAuth(BaseAuth):
         if errors or not auth.is_authenticated():
             reason = auth.get_last_error_reason()
             raise AuthFailed(
-                self, 'SAML login failed: {} ({})'.format(errors, reason)
+                self, 'SAML login failed: {0} ({1})'.format(errors, reason)
             )
 
         attributes = auth.get_attributes()


### PR DESCRIPTION
This fix allows the SAML Backend to support Python 2.6