### PR TITLE
Changed instagram backend to new authorization routes

### DIFF
--- a/social/backends/instagram.py
+++ b/social/backends/instagram.py
@@ -11,8 +11,8 @@ from social.backends.oauth import BaseOAuth2
 
 class InstagramOAuth2(BaseOAuth2):
     name = 'instagram'
-    AUTHORIZATION_URL = 'https://instagram.com/oauth/authorize'
-    ACCESS_TOKEN_URL = 'https://instagram.com/oauth/access_token'
+    AUTHORIZATION_URL = 'https://api.instagram.com/oauth/authorize'
+    ACCESS_TOKEN_URL = 'https://api.instagram.com/oauth/access_token'
     ACCESS_TOKEN_METHOD = 'POST'
 
     def get_user_id(self, details, response):


### PR DESCRIPTION
On last week instagram has changed the authorization routes from 'https://instagram.com/oauth/authorize' to 'https://api.instagram.com/oauth/authorize', and this have break all systems with old route. This change isn't well documented by instagram, but on documentation there is examples with new urls.
https://www.instagram.com/developer/authentication/