### PR TITLE
Revise battlenet endpoint to return account ID and battletag

### DIFF
--- a/docs/backends/battlenet.rst
+++ b/docs/backends/battlenet.rst
@@ -19,12 +19,16 @@ enable ``python-social-auth`` support follow this steps:
         ...
     )
 
-Note: The API returns an accountId which will be used as identifier for the
-user.  If you want to allow the user to choose a username from his own
+Note: If you want to allow the user to choose a username from his own
 characters, some further steps are required, see the use cases part of the
-documentation.
+documentation. To get the account id and battletag use the user_data function, as
+`account id is no longer passed inherently`_.
+
+Another note: If you get a 500 response "Internal Server Error" the API now requires `https on callback endpoints`_.
 
 Further documentation at `Developer Guide`_.
 
 .. _Battlenet Developer Portal: https://dev.battle.net/
 .. _Developer Guide: https://dev.battle.net/docs/read/oauth
+.. _https on callback endpoints: http://us.battle.net/en/forum/topic/17085510584
+.. _account id is no longer passed inherently: http://us.battle.net/en/forum/topic/18300183303

--- a/social/backends/battlenet.py
+++ b/social/backends/battlenet.py
@@ -45,6 +45,6 @@ class BattleNetOAuth2(BaseOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         """ Loads user data from service """
         return self.get_json(
-            'https://eu.api.battle.net/account/user/battletag',
+            'https://eu.api.battle.net/account/user',
             params={'access_token': access_token}
         )


### PR DESCRIPTION
Currently the Battlenet oauth backend only returns battletags and no longer returns the Account ID which is needed to hit other endpoints. This change makes the function return more than just the battletag.

Would love for some other opinions on this, just getting started with Battlenet api stuff today, may be misunderstanding something.

Also updated docs with what it took to get the backend working for me.