### PR TITLE
Fix Django 1.10 deprecation warnings

### DIFF
--- a/social/apps/django_app/urls.py
+++ b/social/apps/django_app/urls.py
@@ -1,27 +1,28 @@
 """URLs module"""
 from django.conf import settings
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
     # Django < 1.4
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 
 from social.utils import setting_name
+from social.apps.django_app import views
 
 
 extra = getattr(settings, setting_name('TRAILING_SLASH'), True) and '/' or ''
 
 
-urlpatterns = patterns('social.apps.django_app.views',
+urlpatterns = [
     # authentication / association
-    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), 'auth',
+    url(r'^login/(?P<backend>[^/]+){0}$'.format(extra), views.auth,
         name='begin'),
-    url(r'^complete/(?P<backend>[^/]+){0}$'.format(extra), 'complete',
+    url(r'^complete/(?P<backend>[^/]+){0}$'.format(extra), views.complete,
         name='complete'),
     # disconnection
-    url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), 'disconnect',
+    url(r'^disconnect/(?P<backend>[^/]+){0}$'.format(extra), views.disconnect,
         name='disconnect'),
     url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>[^/]+){0}$'
-            .format(extra), 'disconnect', name='disconnect_individual'),
-)
+        .format(extra), views.disconnect, name='disconnect_individual'),
+]


### PR DESCRIPTION
In django_app/urls.py:
* Use a list instead of `patterns`
* Use view callables instead of strings

Fixes #804, #754