### PR TITLE
Fix Django 1.10 Deprecation Warning "SubfieldBase has been deprecated."

### DIFF
--- a/social/apps/django_app/default/fields.py
+++ b/social/apps/django_app/default/fields.py
@@ -11,7 +11,7 @@ except ImportError:
     from django.utils.encoding import smart_text
 
 
-class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
+class JSONField(models.TextField):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """


### PR DESCRIPTION
Removed metaclass syntax to break the dependency on django.db.models.SubfieldBase, which has been deprecated in Django 1.9 and will be removed with Django 1.10.

Fixes #804 and #754. Extends fix provided by #806.