### PR TITLE
BaseOAuth2: Store access token in response if it does not exist

### DIFF
--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -392,6 +392,8 @@ class BaseOAuth2(OAuthAuth):
         data = self.user_data(access_token, *args, **kwargs)
         response = kwargs.get('response') or {}
         response.update(data or {})
+        if 'access_token' not in response:
+          response['access_token'] = access_token
         kwargs.update({'response': response, 'backend': self})
         return self.strategy.authenticate(*args, **kwargs)
 


### PR DESCRIPTION
`BaseOAuth2.do_auth` wasn't storing the access token to be passed to the pipeline. As a result, backends inheriting from `BaseOAuth2` wasn't storing the token because `OAuthAuth.extra_data` never had the token information passed to it.

Reference: 
`BaseOAuth1.do_auth`
https://github.com/omab/python-social-auth/blob/master/social/backends/oauth.py#L185-L193

`OAuthAuth.extra_data`
https://github.com/omab/python-social-auth/blob/master/social/backends/oauth.py#L39-L46

Related:
https://github.com/omab/python-social-auth/issues/416