### PR TITLE
SAML: raise AuthMissingParameter if idp param missing

### DIFF
--- a/social/backends/saml.py
+++ b/social/backends/saml.py
@@ -11,7 +11,7 @@ from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 
 from social.backends.base import BaseAuth
-from social.exceptions import AuthFailed
+from social.exceptions import AuthFailed, AuthMissingParameter
 
 # Helpful constants:
 OID_COMMON_NAME = "urn:oid:2.5.4.3"
@@ -256,7 +256,10 @@ class SAMLAuth(BaseAuth):
     def auth_url(self):
         """Get the URL to which we must redirect in order to
         authenticate the user"""
-        idp_name = self.strategy.request_data()['idp']
+        try:
+            idp_name = self.strategy.request_data()['idp']
+        except KeyError:
+            raise AuthMissingParameter(self, 'idp')
         auth = self._create_saml_auth(idp=self.get_idp(idp_name))
         # Below, return_to sets the RelayState, which can contain
         # arbitrary data.  We use it to store the specific SAML IdP

--- a/social/tests/backends/test_saml.py
+++ b/social/tests/backends/test_saml.py
@@ -15,6 +15,7 @@ except ImportError:
     pass
 
 from social.tests.backends.base import BaseBackendTest
+from social.exceptions import AuthMissingParameter
 from social.p3 import urlparse, urlunparse, urlencode, parse_qs
 
 DATA_DIR = path.join(path.dirname(__file__), 'data')
@@ -64,8 +65,6 @@ class SAMLTest(BaseBackendTest):
                                body='foobar')
 
     def do_start(self):
-        # pretend we've started with a URL like /login/saml/?idp=testshib:
-        self.strategy.set_request_data({'idp': 'testshib'}, self.backend)
         start_url = self.backend.start().url
         # Modify the start URL to make the SAML request consistent
         # from test to test:
@@ -91,7 +90,14 @@ class SAMLTest(BaseBackendTest):
 
     def test_login(self):
         """Test that we can authenticate with a SAML IdP (TestShib)"""
+        # pretend we've started with a URL like /login/saml/?idp=testshib:
+        self.strategy.set_request_data({'idp': 'testshib'}, self.backend)
         self.do_login()
+
+    def test_login_no_idp(self):
+        """Logging in without an idp param should raise AuthMissingParameter"""
+        with self.assertRaises(AuthMissingParameter):
+            self.do_start()
 
     def modify_start_url(self, start_url):
         """


### PR DESCRIPTION
The SAML login handler fails with a KeyError if the idp query param is not given, which leads to a 500 response. Raise AuthMissingParameter instead.