### PR TITLE
Fixed use of old private API

### DIFF
--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -4,7 +4,7 @@ from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import authenticate
 from django.shortcuts import redirect
-from django.template import TemplateDoesNotExist, RequestContext, loader
+from django.template import TemplateDoesNotExist, RequestContext, loader, engines
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.utils.translation import get_language
@@ -86,7 +86,7 @@ class DjangoStrategy(BaseStrategy):
         try:
             template = loader.get_template(tpl)
         except TemplateDoesNotExist:
-            template = loader.get_template_from_string(html)
+            template = engines['django'].from_string(html)
         return template.render(RequestContext(self.request, context))
 
     def authenticate(self, backend, *args, **kwargs):


### PR DESCRIPTION
Private API get_template_from_string(template_code) was removed in Django 1.8 because it had no way to choose an engine to compile the template.
