### PR TITLE
Fix wrong evaluation of boolean kwargs

### DIFF
--- a/social/apps/django_app/default/migrations/0001_initial.py
+++ b/social/apps/django_app/default/migrations/0001_initial.py
@@ -7,15 +7,18 @@ from django.conf import settings
 import social.storage.django_orm
 from social.utils import setting_name
 
-user_model = getattr(settings, setting_name('USER_MODEL'), None) or \
-             getattr(settings, 'AUTH_USER_MODEL', None) or \
-             'auth.User'
+USER_MODEL = getattr(settings, setting_name('USER_MODEL'), None) or \
+             getattr(settings, 'AUTH_USER_MODEL', None) or 'auth.User'
+UID_LENGTH = getattr(settings, setting_name('UID_LENGTH'), 255)
+NONCE_SERVER_URL_LENGTH = getattr(settings, setting_name('NONCE_SERVER_URL_LENGTH'), 255)
+ASSOCIATION_SERVER_URL_LENGTH = getattr(settings, setting_name('ASSOCIATION_SERVER_URL_LENGTH'), 255)
+ASSOCIATION_HANDLE_LENGTH = getattr(settings, setting_name('ASSOCIATION_HANDLE_LENGTH'), 255)
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency(user_model),
+        migrations.swappable_dependency(USER_MODEL),
     ]
 
     operations = [
@@ -25,8 +28,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(
                     verbose_name='ID', serialize=False, auto_created=True,
                     primary_key=True)),
-                ('server_url', models.CharField(max_length=255)),
-                ('handle', models.CharField(max_length=255)),
+                ('server_url', models.CharField(max_length=ASSOCIATION_SERVER_URL_LENGTH)),
+                ('handle', models.CharField(max_length=ASSOCIATION_HANDLE_LENGTH)),
                 ('secret', models.CharField(max_length=255)),
                 ('issued', models.IntegerField()),
                 ('lifetime', models.IntegerField()),
@@ -60,7 +63,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(
                     verbose_name='ID', serialize=False, auto_created=True,
                     primary_key=True)),
-                ('server_url', models.CharField(max_length=255)),
+                ('server_url', models.CharField(max_length=NONCE_SERVER_URL_LENGTH)),
                 ('timestamp', models.IntegerField()),
                 ('salt', models.CharField(max_length=65)),
             ],
@@ -76,11 +79,11 @@ class Migration(migrations.Migration):
                     verbose_name='ID', serialize=False, auto_created=True,
                     primary_key=True)),
                 ('provider', models.CharField(max_length=32)),
-                ('uid', models.CharField(max_length=255)),
+                ('uid', models.CharField(max_length=UID_LENGTH)),
                 ('extra_data', social.apps.django_app.default.fields.JSONField(
                     default='{}')),
                 ('user', models.ForeignKey(
-                    related_name='social_auth', to=user_model)),
+                    related_name='social_auth', to=USER_MODEL)),
             ],
             options={
                 'db_table': 'social_auth_usersocialauth',
@@ -89,14 +92,14 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='usersocialauth',
-            unique_together=set([('provider', 'uid')]),
+            unique_together={('provider', 'uid')},
         ),
         migrations.AlterUniqueTogether(
             name='code',
-            unique_together=set([('email', 'code')]),
+            unique_together={('email', 'code')},
         ),
         migrations.AlterUniqueTogether(
             name='nonce',
-            unique_together=set([('server_url', 'timestamp', 'salt')]),
+            unique_together={('server_url', 'timestamp', 'salt')},
         ),
     ]

--- a/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
+++ b/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import models, migrations
+
+from social.utils import setting_name
+
+EMAIL_LENGTH = getattr(settings, setting_name('EMAIL_LENGTH'), 254)
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('default', '0002_add_related_name'),
     ]
@@ -14,6 +18,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='code',
             name='email',
-            field=models.EmailField(max_length=254),
+            field=models.EmailField(max_length=EMAIL_LENGTH),
         ),
     ]

--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -19,6 +19,7 @@ USER_MODEL = getattr(settings, setting_name('USER_MODEL'), None) or \
              getattr(settings, 'AUTH_USER_MODEL', None) or \
              'auth.User'
 UID_LENGTH = getattr(settings, setting_name('UID_LENGTH'), 255)
+EMAIL_LENGTH = getattr(settings, setting_name('EMAIL_LENGTH'), 254)
 NONCE_SERVER_URL_LENGTH = getattr(
     settings, setting_name('NONCE_SERVER_URL_LENGTH'), 255)
 ASSOCIATION_SERVER_URL_LENGTH = getattr(
@@ -98,7 +99,7 @@ class Association(models.Model, DjangoAssociationMixin):
 
 
 class Code(models.Model, DjangoCodeMixin):
-    email = models.EmailField(max_length=254)
+    email = models.EmailField(max_length=EMAIL_LENGTH)
     code = models.CharField(max_length=32, db_index=True)
     verified = models.BooleanField(default=False)
 

--- a/social/pipeline/user.py
+++ b/social/pipeline/user.py
@@ -59,9 +59,8 @@ def create_user(strategy, details, user=None, *args, **kwargs):
     if user:
         return {'is_new': False}
 
-    fields = dict((name, kwargs.get(name) or details.get(name))
-                  for name in strategy.setting('USER_FIELDS',
-                                               USER_FIELDS))
+    fields = dict((name, kwargs.get(name, details.get(name)))
+                  for name in strategy.setting('USER_FIELDS', USER_FIELDS))
     if not fields:
         return
 


### PR DESCRIPTION
After spending too much time debugging why my extra entry in `SOCIAL_AUTH_USER_FIELDS` was `None`, if figured out that the issue lies in `social.pipeline.create_user`. If the extra field in `SOCIAL_AUTH_USER_FIELDS` is a boolean evaluated to `False`, and it´s provided in kwargs, it will return `None` instead of the correct `False` value.

```Python
>>> kwargs = {'field': False}
>>> details = {}
>>> results = kwargs.get('field') or details.get('field')
>>> print(results)
None
>>> results = kwargs.get('field', details.get('field'))
>>> print(results)
False
```