### PR TITLE
Fixed steam not pulling player info b/c of a missing url param: key

### DIFF
--- a/social/backends/steam.py
+++ b/social/backends/steam.py
@@ -19,7 +19,7 @@ class SteamOpenId(OpenIdAuth):
 
     def get_user_details(self, response):
         player = self.get_json(USER_INFO, params={
-            'key': self.setting('API_KEY'),
+            'key': self.setting('SOCIAL_AUTH_STEAM_KEY'),
             'steamids': self._user_id(response)
         })
         if len(player['response']['players']) > 0:


### PR DESCRIPTION
Steam would throw a 400 error when trying to get player information. This was because no key was sent in the URL parameters to steam. Changed API_KEY to SOCIAL_AUTH_STEAM_KEY so that the setting() method pulls the correct value from the settings.py file.