### PR TITLE
Fix xgettext warning due to unknown encoding

### DIFF
--- a/social/backends/weibo.py
+++ b/social/backends/weibo.py
@@ -1,4 +1,4 @@
-# coding:utf8
+# coding:utf-8
 # author:hepochen@gmail.com  https://github.com/hepochen
 """
 Weibo OAuth2 backend, docs at:


### PR DESCRIPTION
While running `python manage.py makemessages` in a Django project, it complains that the `weibo.py` file is not using a known encoding. Replacing `utf8` with `utf-8` removes the warning.

````
xgettext: ./lib/python2.7/site-packages/social/backends/weibo.py:1: Unknown encoding "utf8". Proceeding with ASCII instead.
````