### PR TITLE
Add a provider_domain field to the social_auth models,

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -63,7 +63,7 @@ needed methods:
 * Social user::
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         """Return UserSocialAuth for given provider and uid"""
         raise NotImplementedError('Implement in subclass')
 
@@ -73,7 +73,7 @@ needed methods:
         raise NotImplementedError('Implement in subclass')
 
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
         """Create a UserSocialAuth instance for given user"""
         raise NotImplementedError('Implement in subclass')
 

--- a/social/apps/django_app/default/managers.py
+++ b/social/apps/django_app/default/managers.py
@@ -4,9 +4,10 @@ from django.db import models
 class UserSocialAuthManager(models.Manager):
     """Manager for the UserSocialAuth django model."""
 
-    def get_social_auth(self, provider, uid):
+    def get_social_auth(self, provider, uid, provider_domain=None):
         try:
-            return self.select_related('user').get(provider=provider,
-                                                   uid=uid)
+            return self.select_related('user').get(
+                provider=provider, uid=uid,
+                provider_domain=provider_domain)
         except self.model.DoesNotExist:
             return None

--- a/social/apps/django_app/default/models.py
+++ b/social/apps/django_app/default/models.py
@@ -43,10 +43,11 @@ class AbstractUserSocialAuth(models.Model, DjangoUserMixin):
         abstract = True
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         try:
-            return cls.objects.select_related('user').get(provider=provider,
-                                                          uid=uid)
+            return cls.objects.select_related('user').get(
+                provider=provider, uid=uid,
+                provider_domain=provider_domain)
         except UserSocialAuth.DoesNotExist:
             return None
 

--- a/social/backends/base.py
+++ b/social/backends/base.py
@@ -231,6 +231,9 @@ class BaseAuth(object):
     def get_querystring(self, url, *args, **kwargs):
         return parse_qs(self.request(url, *args, **kwargs).text)
 
+    def get_provider_domain(self):
+        return None
+
     def get_key_and_secret(self):
         """Return tuple with Consumer Key and Consumer Secret for current
         service provider. Must return (key, secret), order *must* be respected.

--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -29,6 +29,10 @@ class FacebookOAuth2(BaseOAuth2):
         ('expires', 'expires')
     ]
 
+    def get_provider_domain(self):
+        key, secret = self.get_key_and_secret()
+        return key
+
     def get_user_details(self, response):
         """Return user details from Facebook account"""
         fullname, first_name, last_name = self.get_user_names(

--- a/social/pipeline/disconnect.py
+++ b/social/pipeline/disconnect.py
@@ -8,10 +8,10 @@ def allowed_to_disconnect(strategy, user, name, user_storage,
 
 
 def get_entries(strategy, user, name, user_storage, association_id=None,
-                *args, **kwargs):
+                provider_domain=None, *args, **kwargs):
     return {
         'entries': user_storage.get_social_auth_for_user(
-            user, name, association_id
+            user, name, association_id, provider_domain
         )
     }
 

--- a/social/pipeline/social_auth.py
+++ b/social/pipeline/social_auth.py
@@ -17,7 +17,9 @@ def auth_allowed(backend, details, response, *args, **kwargs):
 
 def social_user(backend, uid, user=None, *args, **kwargs):
     provider = backend.name
-    social = backend.strategy.storage.user.get_social_auth(provider, uid)
+    provider_domain = backend.get_provider_domain()
+    social = backend.strategy.storage.user.get_social_auth(
+        provider, uid, provider_domain)
     if social:
         if user and social.user != user:
             msg = 'This {0} account is already in use.'.format(provider)
@@ -34,7 +36,7 @@ def associate_user(backend, uid, user=None, social=None, *args, **kwargs):
     if user and not social:
         try:
             social = backend.strategy.storage.user.create_social_auth(
-                user, uid, backend.name
+                user, uid, backend.name, backend.get_provider_domain()
             )
         except Exception as err:
             if not backend.strategy.storage.is_integrity_error(err):
@@ -81,7 +83,8 @@ def associate_by_email(backend, details, user=None, *args, **kwargs):
 
 def load_extra_data(backend, details, response, uid, user, *args, **kwargs):
     social = kwargs.get('social') or \
-             backend.strategy.storage.user.get_social_auth(backend.name, uid)
+             backend.strategy.storage.user.get_social_auth(
+                backend.name, uid, backend.get_provider_domain())
     if social:
         extra_data = backend.extra_data(user, uid, response, details,
                                         *args, **kwargs)

--- a/social/storage/base.py
+++ b/social/storage/base.py
@@ -21,6 +21,7 @@ CLEAN_USERNAME_REGEX = re.compile(r'[^\w.@+_-]+', re.UNICODE)
 class UserMixin(object):
     user = ''
     provider = ''
+    provider_domain = None
     uid = None
     extra_data = None
 
@@ -147,17 +148,18 @@ class UserMixin(object):
         raise NotImplementedError('Implement in subclass')
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         """Return UserSocialAuth for given provider and uid"""
         raise NotImplementedError('Implement in subclass')
 
     @classmethod
-    def get_social_auth_for_user(cls, user, provider=None, id=None):
+    def get_social_auth_for_user(
+            cls, user, provider=None, id=None, provider_domain=None):
         """Return all the UserSocialAuth instances for given user"""
         raise NotImplementedError('Implement in subclass')
 
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
         """Create a UserSocialAuth instance for given user"""
         raise NotImplementedError('Implement in subclass')
 

--- a/social/storage/django_orm.py
+++ b/social/storage/django_orm.py
@@ -75,28 +75,32 @@ class DjangoUserMixin(UserMixin):
         return user_model.objects.filter(**{email_field + '__iexact': email})
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         if not isinstance(uid, six.string_types):
             uid = str(uid)
         try:
-            return cls.objects.get(provider=provider, uid=uid)
+            return cls.objects.get(
+                provider=provider, uid=uid, provider_domain=provider_domain)
         except cls.DoesNotExist:
             return None
 
     @classmethod
-    def get_social_auth_for_user(cls, user, provider=None, id=None):
+    def get_social_auth_for_user(
+            cls, user, provider=None, id=None, provider_domain=None):
         qs = user.social_auth.all()
         if provider:
-            qs = qs.filter(provider=provider)
+            qs = qs.filter(provider=provider, provider_domain=provider_domain)
         if id:
             qs = qs.filter(id=id)
         return qs
 
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
         if not isinstance(uid, six.string_types):
             uid = str(uid)
-        return cls.objects.create(user=user, uid=uid, provider=provider)
+        return cls.objects.create(
+            user=user, uid=uid, provider=provider,
+            provider_domain=provider_domain)
 
 
 class DjangoNonceMixin(NonceMixin):

--- a/social/storage/mongoengine_orm.py
+++ b/social/storage/mongoengine_orm.py
@@ -16,6 +16,7 @@ class MongoengineUserMixin(UserMixin):
     """Social Auth association model"""
     user = None
     provider = StringField(max_length=32)
+    provider_domain = StringField(max_length=256)
     uid = StringField(max_length=255, unique_with='provider')
     extra_data = DictField()
 
@@ -23,19 +24,22 @@ class MongoengineUserMixin(UserMixin):
         return str(self.id)
 
     @classmethod
-    def get_social_auth_for_user(cls, user, provider=None, id=None):
+    def get_social_auth_for_user(
+            cls, user, provider=None, id=None, provider_domain=None):
         qs = cls.objects
         if provider:
-            qs = qs.filter(provider=provider)
+            qs = qs.filter(provider=provider, provider_domain=provider_domain)
         if id:
             qs = qs.filter(id=id)
         return qs.filter(user=user.id)
 
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
         if not isinstance(type(uid), six.string_types):
             uid = str(uid)
-        return cls.objects.create(user=user.id, uid=uid, provider=provider)
+        return cls.objects.create(
+            user=user.id, uid=uid, provider=provider,
+            provider_domain=provider_domain)
 
     @classmethod
     def username_max_length(cls):

--- a/social/tests/models.py
+++ b/social/tests/models.py
@@ -111,20 +111,24 @@ class TestUserSocialAuth(UserMixin, BaseModel):
                 return user
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         social_user = cls.cache_by_uid.get(uid)
-        if social_user and social_user.provider == provider:
+        if social_user and social_user.provider == provider \
+                and social_user.provider_domain == provider_domain:
             return social_user
 
     @classmethod
-    def get_social_auth_for_user(cls, user, provider=None, id=None):
+    def get_social_auth_for_user(
+            cls, user, provider=None, id=None, provider_domain=None):
         return [usa for usa in user.social
                 if provider in (None, usa.provider) and
-                id in (None, usa.id)]
+                id in (None, usa.id) and
+                provider_domain in (None, usa.provider_domain)]
 
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
-        return cls(user=user, provider=provider, uid=uid)
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
+        return cls(user=user, provider=provider, uid=uid,
+                   provider_domain=provider_domain)
 
     @classmethod
     def get_users_by_email(cls, email):

--- a/social/tests/test_pipeline.py
+++ b/social/tests/test_pipeline.py
@@ -17,11 +17,12 @@ class UnknownError(Exception):
 
 class IntegrityErrorUserSocialAuth(TestUserSocialAuth):
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(
+            cls, user, uid, provider, provider_domain=None):
         raise IntegrityError()
 
     @classmethod
-    def get_social_auth(cls, provider, uid):
+    def get_social_auth(cls, provider, uid, provider_domain=None):
         if not hasattr(cls, '_called_times'):
             cls._called_times = 0
         cls._called_times += 1
@@ -30,7 +31,7 @@ class IntegrityErrorUserSocialAuth(TestUserSocialAuth):
             return IntegrityErrorUserSocialAuth(user, provider, uid)
         else:
             return super(IntegrityErrorUserSocialAuth, cls).get_social_auth(
-                provider, uid
+                provider, uid, provider_domain
             )
 
 
@@ -45,7 +46,7 @@ class IntegrityErrorStorage(TestStorage):
 
 class UnknownErrorUserSocialAuth(TestUserSocialAuth):
     @classmethod
-    def create_social_auth(cls, user, uid, provider):
+    def create_social_auth(cls, user, uid, provider, provider_domain=None):
         raise UnknownError()
 
 


### PR DESCRIPTION
and an optional corresponding argument to social_auth creation and search functions
(namely create_social_auth, get_social_auth and get_social_auth_for_user.)
Also include this provider_domain in the uniqueness constraint.
This allows to account for the fact that the UID may be local to a specific instance of a given provider type.
Use case 1: We can have multiple OAuth2 servers based on Wordpress OAuth Server. The UID here is local to a specific Wordpress installation, so I'd include the wordpress server URL as provider_domain.
Use case 2: Facebook uids are keyed to a app_id, so different apps will receive a different uid for the same user. There is a global uniqueness constraint for app-depedent uids, but that uniqueness does not extend to test accounts. So it is safer to include the app_id as provider_domain in facebook social_auth models.
