### PR TITLE
Pass response to AuthCancel exception

### DIFF
--- a/social/backends/evernote.py
+++ b/social/backends/evernote.py
@@ -50,7 +50,7 @@ class EvernoteOAuth(BaseOAuth1):
         except HTTPError as err:
             # Evernote returns a 401 error when AuthCanceled
             if err.response.status_code == 401:
-                raise AuthCanceled(self)
+                raise AuthCanceled(self, response=err.response)
             else:
                 raise
 

--- a/social/backends/weixin.py
+++ b/social/backends/weixin.py
@@ -89,7 +89,7 @@ class WeixinOAuth2(BaseOAuth2):
             )
         except HTTPError as err:
             if err.response.status_code == 400:
-                raise AuthCanceled(self)
+                raise AuthCanceled(self, response=err.response)
             else:
                 raise
         except KeyError:

--- a/social/exceptions.py
+++ b/social/exceptions.py
@@ -41,6 +41,10 @@ class AuthFailed(AuthException):
 
 class AuthCanceled(AuthException):
     """Auth process was canceled by user."""
+    def __init__(self, *args, **kwargs):
+        self.response = kwargs.pop('response', None)
+        super(AuthCanceled, self).__init__(*args, **kwargs)
+
     def __str__(self):
         return 'Authentication process canceled'
 

--- a/social/tests/backends/test_evernote.py
+++ b/social/tests/backends/test_evernote.py
@@ -34,12 +34,14 @@ class EvernoteOAuth1CanceledTest(EvernoteOAuth1Test):
     access_token_status = 401
 
     def test_login(self):
-        with self.assertRaises(AuthCanceled):
+        with self.assertRaises(AuthCanceled) as cm:
             self.do_login()
+        self.assertTrue(cm.exception.response is not None)
 
     def test_partial_pipeline(self):
-        with self.assertRaises(AuthCanceled):
+        with self.assertRaises(AuthCanceled) as cm:
             self.do_partial_pipeline()
+        self.assertTrue(cm.exception.response is not None)
 
 
 class EvernoteOAuth1ErrorTest(EvernoteOAuth1Test):

--- a/social/tests/backends/test_facebook.py
+++ b/social/tests/backends/test_facebook.py
@@ -1,6 +1,6 @@
 import json
 
-from social.exceptions import AuthUnknownError
+from social.exceptions import AuthUnknownError, AuthCanceled
 
 from social.tests.backends.oauth import OAuth2Test
 
@@ -42,3 +42,25 @@ class FacebookOAuth2WrongUserDataTest(FacebookOAuth2Test):
     def test_partial_pipeline(self):
         with self.assertRaises(AuthUnknownError):
             self.do_partial_pipeline()
+
+
+class FacebookOAuth2AuthCancelTest(FacebookOAuth2Test):
+    access_token_status = 400
+    access_token_body = json.dumps({
+        'error': {
+            'message': "redirect_uri isn't an absolute URI. Check RFC 3986.",
+            'code': 191,
+            'type': 'OAuthException',
+            'fbtrace_id': '123Abc'
+        }
+    })
+
+    def test_login(self):
+        with self.assertRaises(AuthCanceled) as cm:
+            self.do_login()
+        self.assertIn('error', cm.exception.response.json())
+
+    def test_partial_pipeline(self):
+        with self.assertRaises(AuthCanceled) as cm:
+            self.do_partial_pipeline()
+        self.assertIn('error', cm.exception.response.json())

--- a/social/utils.py
+++ b/social/utils.py
@@ -229,7 +229,7 @@ def handle_http_errors(func):
             return func(*args, **kwargs)
         except requests.HTTPError as err:
             if err.response.status_code == 400:
-                raise AuthCanceled(args[0])
+                raise AuthCanceled(args[0], response=err.response)
             elif err.response.status_code == 503:
                 raise AuthUnreachableProvider(args[0])
             else:


### PR DESCRIPTION
When oauth provider responds with error, we only got `AuthCanceled` exception.
It is hard to understand, why provider refuses to accept our request. We can't easily log the response.

This patch saves response in attribute of  `AuthCanceled` exception (if it is possible).
And users of library can log the response to understand, what really happened.