### PR TITLE
Removed broken link in use cases docs fixing #860

### DIFF
--- a/docs/use_cases.rst
+++ b/docs/use_cases.rst
@@ -143,9 +143,6 @@ will be done by AJAX. It doesn't return the user information, but that's
 something that can be extended and filled to suit the project where it's going
 to be used.
 
-This topic is well addressed in `A Rest API using Django and authentication
-with OAuth2 AND third parties!`_ wrote by `Félix Descôteaux`_.
-
 
 Multiple scopes per provider
 ----------------------------
@@ -313,5 +310,3 @@ Set this pipeline after ``social_user``::
 
 .. _python-social-auth: https://github.com/omab/python-social-auth
 .. _People API endpoint: https://developers.google.com/+/api/latest/people/list
-.. _Félix Descôteaux: https://twitter.com/FelixDescoteaux
-.. _A Rest API using Django and authentication with OAuth2 AND third parties!: http://httplambda.com/a-rest-api-with-django-and-oauthw-authentication/


### PR DESCRIPTION
Link is broken and points to a SPAM/Scam website. Looked for a replacement link but it appears the author no longer has a blog, I checked his twitter and googled him and the article. Fixes issue #860 