### PR TITLE
Fix settings variable 'PIPELINE' to 'SOCIAL_AUTH_PIPELINE'

### DIFF
--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -95,7 +95,7 @@ class BaseStrategy(object):
         return OpenIdStore(self)
 
     def get_pipeline(self):
-        return self.setting('PIPELINE', DEFAULT_AUTH_PIPELINE)
+        return self.setting('SOCIAL_AUTH_PIPELINE', DEFAULT_AUTH_PIPELINE)
 
     def get_disconnect_pipeline(self):
         return self.setting('DISCONNECT_PIPELINE', DEFAULT_DISCONNECT_PIPELINE)

--- a/social/tests/strategy.py
+++ b/social/tests/strategy.py
@@ -106,7 +106,7 @@ class TestStrategy(BaseStrategy):
         return user
 
     def get_pipeline(self):
-        return self.setting('PIPELINE', (
+        return self.setting('SOCIAL_AUTH_PIPELINE', (
             'social.pipeline.social_auth.social_details',
             'social.pipeline.social_auth.social_uid',
             'social.pipeline.social_auth.auth_allowed',


### PR DESCRIPTION
Changed variable name to be more specific.
'PIPELINE' variable is also a settings variable used in django-pipeline, which causes an error when used together. #838 