### PR TITLE
django 1.8+ compat to ensure to_python is always called when accessing result from db..

### DIFF
--- a/social/apps/django_app/default/fields.py
+++ b/social/apps/django_app/default/fields.py
@@ -20,6 +20,9 @@ class JSONField(models.TextField):
         kwargs.setdefault('default', '{}')
         super(JSONField, self).__init__(*args, **kwargs)
 
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
+
     def to_python(self, value):
         """
         Convert the input JSON value into python structures, raises


### PR DESCRIPTION
Without this extra_data field can be returned as its raw serialized string...