### PR TITLE
VULNERABILITY - BaseStrategy.validate_email() doesn't actually check email address

### DIFF
--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -131,6 +131,8 @@ class BaseStrategy(object):
         verification_code = self.storage.code.get_code(code)
         if not verification_code or verification_code.code != code:
             return False
+        elif verification_code.email != email:
+            return False
         else:
             verification_code.verify()
             return True


### PR DESCRIPTION
BaseStrategy.validate_email() will check if a Code object exists, but not that the Code object's email field matches the email parameter passed to the method; indeed, the email parameter isn't used at all.

In a nutshell: if you have the social.pipeline.mail.mail_validation backend set up with SOCIAL_AUTH_PASSWORDLESS, you can gain access to any user account on the system. Log in once to get a genuine verification code, take note of the URL callback to the 'social:complete' view (e.g. /social/complete/email/?verification_code=b855c8966abf45e6aaac89af9b12f7c8&email=attacker%40gmail.com ), then hit the same URL but with a different email (e.g. /social/complete/email/?verification_code=b855c8966abf45e6aaac89af9b12f7c8&email=admin%40site.com).