### PR TITLE
Internationalization support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,18 @@ def get_packages():
     return packages
 
 
+if 'sdist' in sys.argv or 'develop' in sys.argv:
+    os.chdir('social/apps/django_app/default')
+    try:
+        from django.core import management
+        management.call_command('compilemessages', stdout=sys.stderr, verbosity=1)
+    except ImportError:
+        if 'sdist' in sys.argv:
+            raise
+    finally:
+        os.chdir('../../../..')
+
+
 requirements_file, tests_requirements_file = {
     False: ('requirements.txt', 'social/tests/requirements.txt'),
     True: ('requirements-python3.txt', 'social/tests/requirements-python3.txt')

--- a/social/apps/django_app/default/locale/ru/LC_MESSAGES/django.po
+++ b/social/apps/django_app/default/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,143 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-18 15:42+0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Alexey Trofimov <trofimovL@metadesign.ru>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgid "This {0} account is already in use."
+msgstr "Этот аккаунт {0} уже используется."
+
+msgid "Authentication error"
+msgstr "Ошибка аутентификации"
+
+msgid "Authentication Failed"
+msgstr "Аутентификации не удалась"
+
+msgid "Jawbone error was {0}"
+msgstr "Ошибка Jawbone: {0}"
+
+msgid "User refused the access"
+msgstr "Пользователь отклонил доступ"
+
+msgid "Error was "
+msgstr "Произошла ошибка "
+
+msgid "Missing unauthorized token"
+msgstr "Отсутствует неавторизованный токен"
+
+msgid "Incorrect tokens"
+msgstr "Неправильные токены"
+
+msgid "Missing oauth_token"
+msgstr "Отсутствует OAuth токен"
+
+msgid "Missing oauth_token_secret"
+msgstr "Отсутствует OAuth секрет"
+
+msgid "Cannot get user details: API error"
+msgstr "Невозможно получить информацию о пользователе: ошибка API"
+
+msgid "Wrong authorization key"
+msgstr "Неверный ключ авторизации"
+
+msgid "Missing Steam Id"
+msgstr "Отсутствует Steam Id"
+
+msgid "No AccountSid returned"
+msgstr "Сервер не вернул AccountSid"
+
+msgid "VK.com authentication is not completed"
+msgstr "Авторизация на vk.com не завершена"
+
+msgid "VK.com authentication failed: Invalid Hash"
+msgstr "Авторизация на vk.com не удалась: неверный хэш"
+
+msgid "VK.com authentication failed: invalid auth key"
+msgstr "Авторизация на vk.com не удалась: неверный ключ"
+
+msgid "User doesn't belong to the organization"
+msgstr "Пользователь не принадлежит данной организации"
+
+msgid "An error ocurred while retrieving users Facebook data"
+msgstr "Ошибка при получении данных пользователя с Facebook"
+
+msgid "Missing template or html parameters"
+msgstr "Отсутствуют параметры шаблонов или HTML"
+
+msgid "Authentication process canceled"
+msgstr "Процесс аутентификации отменён"
+
+msgid "Authentication process was canceled"
+msgstr "Процесс аутентификации отменён"
+
+msgid "Authentication failed: {0}"
+msgstr "Аутентификация не удалась: {0}"
+
+msgid "An unknown error happened while authenticating {0}"
+msgstr "Во время аутентификации произошла неизвестная ошибка {0}"
+
+msgid "Token error: {0}"
+msgstr "Ошибка токена: {0}"
+
+msgid "Missing needed parameter {0}"
+msgstr "Отсутствует необходимый параметр {0}"
+
+msgid "Session value state missing."
+msgstr "Значение состояния отсутствует в сессии."
+
+msgid "Wrong state parameter given."
+msgstr "Неверное значение параметра состояния."
+
+msgid "User revoke access to the token"
+msgstr "Пользователь отозвал права доступа к токену"
+
+msgid "Your credentials aren't allowed"
+msgstr "Нет доступа с вашими учётными данными"
+
+msgid "The authentication provider could not be reached"
+msgstr "Невозможно подключиться к службе аутентификации"
+
+msgid "Email couldn't be validated"
+msgstr "Невозможно проверить адрес электронной почты"
+
+msgid "Bitbucket account has no verified email"
+msgstr "Аккаунт Bitbucket не содержит подтвержденного адреса электронной почты"
+
+msgid "Refresh tokens for Bitbucket have not been implemented"
+msgstr "Обновление токенов для Bitbucket еще не реализовано"
+
+msgid "OpenID discovery error: {0}"
+msgstr "Ошибка обнаружения OpenID: {0}"
+
+msgid "Incorrect id_token: iat"
+msgstr "Неправильный id_token: iat"
+
+msgid "Incorrect id_token: nonce"
+msgstr "Неправильный id_token: nonce"
+
+msgid "Unknown request type {0}. How should it be signed?"
+msgstr "Неизвестный тип запроса {0}. Как он должен быть подписан?"
+
+msgid "Unknown error"
+msgstr "Неизвестная ошибка"
+
+msgid "The given email address is associated with another account"
+msgstr "Указанный адрес электронной почты связан с другим аккаунтом"
+
+msgid "SAML login failed: {0} ({1})"
+msgstr "Вход через SAML не удался: {0} ({1})"

--- a/social/backends/bitbucket.py
+++ b/social/backends/bitbucket.py
@@ -39,7 +39,7 @@ class BitbucketOAuthBase(object):
 
         if self.setting('VERIFIED_EMAILS_ONLY', False) and \
            not address['is_confirmed']:
-            raise AuthForbidden(self, 'Bitbucket account has no verified email')
+            raise AuthForbidden(self, self.strategy.ugettext('Bitbucket account has no verified email'))
 
         user = self._get_user(access_token)
         if email:
@@ -79,8 +79,8 @@ class BitbucketOAuth2(BitbucketOAuthBase, BaseOAuth2):
                              params={'access_token': access_token})
 
     def refresh_token(self, *args, **kwargs):
-        raise NotImplementedError('Refresh tokens for Bitbucket have '
-                                  'not been implemented')
+        raise NotImplementedError(self.strategy.ugettext('Refresh tokens for Bitbucket have '
+                                  'not been implemented'))
 
 
 class BitbucketOAuth(BitbucketOAuthBase, BaseOAuth1):

--- a/social/backends/exacttarget.py
+++ b/social/backends/exacttarget.py
@@ -71,7 +71,7 @@ class ExactTargetOAuth2(BaseOAuth2):
         """Completes login process, must return user instance"""
         token = self.data.get('jwt', {})
         if not token:
-            raise AuthFailed(self, 'Authentication Failed')
+            raise AuthFailed(self, self.strategy.ugettext('Authentication Failed'))
         return self.do_auth(token, *args, **kwargs)
 
     def extra_data(self, user, uid, response, details=None, *args, **kwargs):

--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -109,8 +109,8 @@ class FacebookOAuth2(BaseOAuth2):
             # data is needed (it contains the user ID used to identify the
             # account on further logins), this app cannot allow it to
             # continue with the auth process.
-            raise AuthUnknownError(self, 'An error ocurred while retrieving '
-                                         'users Facebook data')
+            raise AuthUnknownError(self, self.strategy.ugettext('An error ocurred while retrieving '
+                                         'users Facebook data'))
 
         data['access_token'] = access_token
         if 'expires' in response:

--- a/social/backends/gae.py
+++ b/social/backends/gae.py
@@ -35,6 +35,6 @@ class GoogleAppEngineAuth(BaseAuth):
     def auth_complete(self, *args, **kwargs):
         """Completes login process, must return user instance."""
         if not users.get_current_user():
-            raise AuthException('Authentication error')
+            raise AuthException(self.strategy.ugettext('Authentication error'))
         kwargs.update({'response': '', 'backend': self})
         return self.strategy.authenticate(*args, **kwargs)

--- a/social/backends/github.py
+++ b/social/backends/github.py
@@ -82,7 +82,7 @@ class GithubMemberOAuth2(GithubOAuth2):
             # will be 204, see http://bit.ly/ZS6vFl
             if err.response.status_code != 204:
                 raise AuthFailed(self,
-                                 'User doesn\'t belong to the organization')
+                                 self.strategy.ugettext('User doesn\'t belong to the organization'))
         return user_data
 
     def member_url(self, user_data):

--- a/social/backends/jawbone.py
+++ b/social/backends/jawbone.py
@@ -48,7 +48,7 @@ class JawboneOAuth2(BaseOAuth2):
             if error == 'access_denied':
                 raise AuthCanceled(self)
             else:
-                raise AuthUnknownError(self, 'Jawbone error was {0}'.format(
+                raise AuthUnknownError(self, self.strategy.ugettext('Jawbone error was {0}').format(
                     error
                 ))
         return super(JawboneOAuth2, self).process_error(data)

--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -168,8 +168,8 @@ class BaseOAuth1(OAuthAuth):
     def process_error(self, data):
         if 'oauth_problem' in data:
             if data['oauth_problem'] == 'user_refused':
-                raise AuthCanceled(self, 'User refused the access')
-            raise AuthUnknownError(self, 'Error was ' + data['oauth_problem'])
+                raise AuthCanceled(self, self.strategy.ugettext('User refused the access'))
+            raise AuthUnknownError(self, self.strategy.ugettext('Error was ') + data['oauth_problem'])
 
     @handle_http_errors
     def auth_complete(self, *args, **kwargs):
@@ -196,12 +196,12 @@ class BaseOAuth1(OAuthAuth):
         name = self.name + self.UNATHORIZED_TOKEN_SUFIX
         unauthed_tokens = self.strategy.session_get(name, [])
         if not unauthed_tokens:
-            raise AuthTokenError(self, 'Missing unauthorized token')
+            raise AuthTokenError(self, self.strategy.ugettext('Missing unauthorized token'))
 
         data_token = self.data.get(self.OAUTH_TOKEN_PARAMETER_NAME)
 
         if data_token is None:
-            raise AuthTokenError(self, 'Missing unauthorized token')
+            raise AuthTokenError(self, self.strategy.ugettext('Missing unauthorized token'))
 
         token = None
         for utoken in unauthed_tokens:
@@ -214,7 +214,7 @@ class BaseOAuth1(OAuthAuth):
                 token = utoken
                 break
         else:
-            raise AuthTokenError(self, 'Incorrect tokens')
+            raise AuthTokenError(self, self.strategy.ugettext('Incorrect tokens'))
         return token
 
     def set_unauthorized_token(self):
@@ -273,9 +273,9 @@ class BaseOAuth1(OAuthAuth):
             resource_owner_key = token.get('oauth_token')
             resource_owner_secret = token.get('oauth_token_secret')
             if not resource_owner_key:
-                raise AuthTokenError(self, 'Missing oauth_token')
+                raise AuthTokenError(self, self.strategy.ugettext('Missing oauth_token'))
             if not resource_owner_secret:
-                raise AuthTokenError(self, 'Missing oauth_token_secret')
+                raise AuthTokenError(self, self.strategy.ugettext('Missing oauth_token_secret'))
         else:
             resource_owner_key = None
             resource_owner_secret = None

--- a/social/backends/odnoklassniki.py
+++ b/social/backends/odnoklassniki.py
@@ -95,7 +95,7 @@ class OdnoklassnikiApp(BaseAuth):
             details['extra_data_list'] = fields + auth_data_fields
             kwargs.update({'backend': self, 'response': details})
         else:
-            raise AuthFailed(self, 'Cannot get user details: API error')
+            raise AuthFailed(self, self.strategy.ugettext('Cannot get user details: API error'))
         return self.strategy.authenticate(*args, **kwargs)
 
     def get_auth_sig(self):
@@ -116,7 +116,7 @@ class OdnoklassnikiApp(BaseAuth):
         correct_key = self.get_auth_sig()
         key = self.data['auth_sig'].lower()
         if correct_key != key:
-            raise AuthFailed(self, 'Wrong authorization key')
+            raise AuthFailed(self, self.strategy.ugettext('Wrong authorization key'))
 
 
 def odnoklassniki_oauth_sig(data, client_secret):
@@ -166,6 +166,6 @@ def odnoklassniki_api(backend, data, api_url, public_key, client_secret,
     elif request_type == 'iframe_nosession':
         data['sig'] = odnoklassniki_iframe_sig(data, client_secret)
     else:
-        msg = 'Unknown request type {0}. How should it be signed?'
+        msg = self.strategy.ugettext('Unknown request type {0}. How should it be signed?')
         raise AuthFailed(backend, msg.format(request_type))
     return backend.get_json(api_url + 'fb.do', params=data)

--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -175,7 +175,7 @@ class OpenIdAuth(BaseAuth):
 
     def process_error(self, data):
         if not data:
-            raise AuthException(self, 'OpenID relying party endpoint')
+            raise AuthException(self, self.strategy.ugettext('OpenID relying party endpoint'))
         elif data.status == FAILURE:
             raise AuthFailed(self, data.message)
         elif data.status == CANCEL:
@@ -244,7 +244,7 @@ class OpenIdAuth(BaseAuth):
             return self.consumer().begin(url_add_parameters(self.openid_url(),
                                          params))
         except DiscoveryFailure as err:
-            raise AuthException(self, 'OpenID discovery error: {0}'.format(
+            raise AuthException(self, self.strategy.ugettext('OpenID discovery error: {0}').format(
                 err
             ))
 
@@ -338,18 +338,18 @@ class OpenIdConnectAuth(BaseOAuth2):
         # Verify the token was issued in the last 10 minutes
         utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
         if id_token['iat'] < (utc_timestamp - 600):
-            raise AuthTokenError(self, 'Incorrect id_token: iat')
+            raise AuthTokenError(self, self.strategy.ugettext('Incorrect id_token: iat'))
 
         # Validate the nonce to ensure the request was not modified
         nonce = id_token.get('nonce')
         if not nonce:
-            raise AuthTokenError(self, 'Incorrect id_token: nonce')
+            raise AuthTokenError(self, self.strategy.ugettext('Incorrect id_token: nonce'))
 
         nonce_obj = self.get_nonce(nonce)
         if nonce_obj:
             self.remove_nonce(nonce_obj.id)
         else:
-            raise AuthTokenError(self, 'Incorrect id_token: nonce')
+            raise AuthTokenError(self, self.strategy.ugettext('Incorrect id_token: nonce'))
         return id_token
 
     def request_access_token(self, *args, **kwargs):

--- a/social/backends/shopify.py
+++ b/social/backends/shopify.py
@@ -76,7 +76,7 @@ class ShopifyOAuth2(BaseOAuth2):
             raise AuthCanceled(self)
         else:
             if not access_token:
-                raise AuthFailed(self, 'Authentication Failed')
+                raise AuthFailed(self, self.strategy.ugettext('Authentication Failed'))
         return self.do_auth(access_token, shop_url, shopify_session.url,
                             *args, **kwargs)
 

--- a/social/backends/steam.py
+++ b/social/backends/steam.py
@@ -43,5 +43,5 @@ class SteamOpenId(OpenIdAuth):
     def _user_id(self, response):
         user_id = response.identity_url.rsplit('/', 1)[-1]
         if not user_id.isdigit():
-            raise AuthFailed(self, 'Missing Steam Id')
+            raise AuthFailed(self, self.strategy.ugettext('Missing Steam Id'))
         return user_id

--- a/social/backends/twilio.py
+++ b/social/backends/twilio.py
@@ -34,6 +34,6 @@ class TwilioAuth(BaseAuth):
         """Completes loging process, must return user instance"""
         account_sid = self.data.get('AccountSid')
         if not account_sid:
-            raise ValueError('No AccountSid returned')
+            raise ValueError(self.strategy.ugettext('No AccountSid returned'))
         kwargs.update({'response': self.data, 'backend': self})
         return self.strategy.authenticate(*args, **kwargs)

--- a/social/backends/vk.py
+++ b/social/backends/vk.py
@@ -51,7 +51,7 @@ class VKontakteOpenAPI(BaseAuth):
             'vk_app_' + self.setting('APP_ID')
         )
         if 'id' not in self.data or not session_value:
-            raise ValueError('VK.com authentication is not completed')
+            raise ValueError(self.strategy.ugettext('VK.com authentication is not completed'))
 
         mapping = parse_qs(session_value)
         check_str = ''.join(item + '=' + mapping[item]
@@ -60,7 +60,7 @@ class VKontakteOpenAPI(BaseAuth):
         key, secret = self.get_key_and_secret()
         hash = md5((check_str + secret).encode('utf-8')).hexdigest()
         if hash != mapping['sig'] or int(mapping['expire']) < time():
-            raise ValueError('VK.com authentication failed: Invalid Hash')
+            raise ValueError(self.strategy.ugettext('VK.com authentication failed: Invalid Hash'))
 
         kwargs.update({'backend': self,
                        'response': self.user_data(mapping['mid'])})
@@ -110,7 +110,7 @@ class VKOAuth2(BaseOAuth2):
 
         if data and data.get('error'):
             error = data['error']
-            msg = error.get('error_msg', 'Unknown error')
+            msg = error.get('error_msg', self.strategy.ugettext('Unknown error'))
             if error.get('error_code') == 5:
                 raise AuthTokenRevoked(self, msg)
             else:
@@ -152,8 +152,8 @@ class VKAppOAuth2(VKOAuth2):
                                       self.data.get('viewer_id'),
                                       secret]).encode('utf-8')).hexdigest()
             if check_key != auth_key:
-                raise ValueError('VK.com authentication failed: invalid '
-                                 'auth key')
+                raise ValueError(self.strategy.ugettext('VK.com authentication failed: invalid '
+                                 'auth key'))
 
         user_check = self.setting('USERMODE')
         user_id = self.data.get('viewer_id')

--- a/social/exceptions.py
+++ b/social/exceptions.py
@@ -35,8 +35,8 @@ class AuthFailed(AuthException):
     def __str__(self):
         msg = super(AuthFailed, self).__str__()
         if msg == 'access_denied':
-            return 'Authentication process was canceled'
-        return 'Authentication failed: {0}'.format(msg)
+            return self.backend.strategy.ugettext('Authentication process was canceled')
+        return self.backend.strategy.ugettext('Authentication failed: {0}').format(msg)
 
 
 class AuthCanceled(AuthException):
@@ -46,21 +46,21 @@ class AuthCanceled(AuthException):
         super(AuthCanceled, self).__init__(*args, **kwargs)
 
     def __str__(self):
-        return 'Authentication process canceled'
+        return self.backend.strategy.ugettext('Authentication process canceled')
 
 
 class AuthUnknownError(AuthException):
     """Unknown auth process error."""
     def __str__(self):
         msg = super(AuthUnknownError, self).__str__()
-        return 'An unknown error happened while authenticating {0}'.format(msg)
+        return self.backend.strategy.ugettext('An unknown error happened while authenticating {0}').format(msg)
 
 
 class AuthTokenError(AuthException):
     """Auth token error."""
     def __str__(self):
         msg = super(AuthTokenError, self).__str__()
-        return 'Token error: {0}'.format(msg)
+        return self.backend.strategy.ugettext('Token error: {0}').format(msg)
 
 
 class AuthMissingParameter(AuthException):
@@ -70,19 +70,19 @@ class AuthMissingParameter(AuthException):
         super(AuthMissingParameter, self).__init__(backend, *args, **kwargs)
 
     def __str__(self):
-        return 'Missing needed parameter {0}'.format(self.parameter)
+        return self.backend.strategy.ugettext('Missing needed parameter {0}').format(self.parameter)
 
 
 class AuthStateMissing(AuthException):
     """State parameter is incorrect."""
     def __str__(self):
-        return 'Session value state missing.'
+        return self.backend.strategy.ugettext('Session value state missing.')
 
 
 class AuthStateForbidden(AuthException):
     """State parameter is incorrect."""
     def __str__(self):
-        return 'Wrong state parameter given.'
+        return self.backend.strategy.ugettext('Wrong state parameter given.')
 
 
 class AuthAlreadyAssociated(AuthException):
@@ -93,21 +93,21 @@ class AuthAlreadyAssociated(AuthException):
 class AuthTokenRevoked(AuthException):
     """User revoked the access_token in the provider."""
     def __str__(self):
-        return 'User revoke access to the token'
+        return self.backend.strategy.ugettext('User revoke access to the token')
 
 
 class AuthForbidden(AuthException):
     """Authentication for this user is forbidden"""
     def __str__(self):
-        return 'Your credentials aren\'t allowed'
+        return self.backend.strategy.ugettext('Your credentials aren\'t allowed')
 
 
 class AuthUnreachableProvider(AuthException):
     """Cannot reach the provider"""
     def __str__(self):
-        return 'The authentication provider could not be reached'
+        return self.backend.strategy.ugettext('The authentication provider could not be reached')
 
 
 class InvalidEmail(AuthException):
     def __str__(self):
-        return 'Email couldn\'t be validated'
+        return self.backend.strategy.ugettext('Email couldn\'t be validated')

--- a/social/pipeline/social_auth.py
+++ b/social/pipeline/social_auth.py
@@ -20,7 +20,7 @@ def social_user(backend, uid, user=None, *args, **kwargs):
     social = backend.strategy.storage.user.get_social_auth(provider, uid)
     if social:
         if user and social.user != user:
-            msg = 'This {0} account is already in use.'.format(provider)
+            msg = backend.strategy.ugettext('This {0} account is already in use.').format(provider)
             raise AuthAlreadyAssociated(backend, msg)
         elif not user:
             user = social.user
@@ -73,7 +73,7 @@ def associate_by_email(backend, details, user=None, *args, **kwargs):
         elif len(users) > 1:
             raise AuthException(
                 backend,
-                'The given email address is associated with another account'
+                backend.strategy.ugettext('The given email address is associated with another account')
             )
         else:
             return {'user': users[0]}

--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -14,7 +14,7 @@ class BaseTemplateStrategy(object):
 
     def render(self, tpl=None, html=None, context=None):
         if not tpl and not html:
-            raise ValueError(self.ugettext('Missing template or html parameters'))
+            raise ValueError(self.strategy.ugettext('Missing template or html parameters'))
         context = context or {}
         if tpl:
             return self.render_template(tpl, context)

--- a/social/strategies/base.py
+++ b/social/strategies/base.py
@@ -14,7 +14,7 @@ class BaseTemplateStrategy(object):
 
     def render(self, tpl=None, html=None, context=None):
         if not tpl and not html:
-            raise ValueError('Missing template or html parameters')
+            raise ValueError(self.ugettext('Missing template or html parameters'))
         context = context or {}
         if tpl:
             return self.render_template(tpl, context)
@@ -150,6 +150,9 @@ class BaseStrategy(object):
     def get_backends(self):
         """Return configured backends"""
         return self.setting('AUTHENTICATION_BACKENDS', [])
+
+    def ugettext(self, message):
+        return message
 
     # Implement the following methods on strategies sub-classes
 

--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.template import TemplateDoesNotExist, RequestContext, loader
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
-from django.utils.translation import get_language
+from django.utils.translation import get_language, ugettext
 
 from social.strategies.base import BaseStrategy, BaseTemplateStrategy
 
@@ -29,6 +29,9 @@ class DjangoStrategy(BaseStrategy):
         self.request = request
         self.session = request.session if request else {}
         super(DjangoStrategy, self).__init__(storage, tpl)
+
+    def ugettext(self, message):
+        return ugettext(message)
 
     def get_setting(self, name):
         value = getattr(settings, name)
@@ -81,7 +84,7 @@ class DjangoStrategy(BaseStrategy):
 
     def render_html(self, tpl=None, html=None, context=None):
         if not tpl and not html:
-            raise ValueError('Missing template or html parameters')
+            raise ValueError(self.ugettext('Missing template or html parameters'))
         context = context or {}
         try:
             template = loader.get_template(tpl)

--- a/social/strategies/webpy_strategy.py
+++ b/social/strategies/webpy_strategy.py
@@ -38,7 +38,7 @@ class WebpyStrategy(BaseStrategy):
 
     def render_html(self, tpl=None, html=None, context=None):
         if not tpl and not html:
-            raise ValueError('Missing template or html parameters')
+            raise ValueError(self.ugettext('Missing template or html parameters'))
         context = context or {}
         if tpl:
             tpl = web.template.frender(tpl)

--- a/social/tests/test_exceptions.py
+++ b/social/tests/test_exceptions.py
@@ -30,7 +30,7 @@ class BaseExceptionTestCase(unittest.TestCase):
 
 
 class WrongBackendTest(BaseExceptionTestCase):
-    exception = WrongBackend(foobar)
+    exception = WrongBackend('foobar')
     expected_message = 'Incorrect authentication service "foobar"'
 
 

--- a/social/tests/test_exceptions.py
+++ b/social/tests/test_exceptions.py
@@ -1,4 +1,8 @@
 import unittest2 as unittest
+from social.backends.base import BaseAuth
+
+from social.tests.models import TestStorage
+from social.tests.strategy import TestStrategy
 
 from social.exceptions import SocialAuthBaseException, WrongBackend, \
                               AuthFailed, AuthTokenError, \
@@ -7,6 +11,9 @@ from social.exceptions import SocialAuthBaseException, WrongBackend, \
                               AuthCanceled, AuthUnknownError, \
                               AuthStateForbidden, AuthAlreadyAssociated, \
                               AuthTokenRevoked
+
+
+foobar = BaseAuth(TestStrategy(TestStorage))
 
 
 class BaseExceptionTestCase(unittest.TestCase):
@@ -23,32 +30,32 @@ class BaseExceptionTestCase(unittest.TestCase):
 
 
 class WrongBackendTest(BaseExceptionTestCase):
-    exception = WrongBackend('foobar')
+    exception = WrongBackend(foobar)
     expected_message = 'Incorrect authentication service "foobar"'
 
 
 class AuthFailedTest(BaseExceptionTestCase):
-    exception = AuthFailed('foobar', 'wrong_user')
+    exception = AuthFailed(foobar, 'wrong_user')
     expected_message = 'Authentication failed: wrong_user'
 
 
 class AuthFailedDeniedTest(BaseExceptionTestCase):
-    exception = AuthFailed('foobar', 'access_denied')
+    exception = AuthFailed(foobar, 'access_denied')
     expected_message = 'Authentication process was canceled'
 
 
 class AuthTokenErrorTest(BaseExceptionTestCase):
-    exception = AuthTokenError('foobar', 'Incorrect tokens')
+    exception = AuthTokenError(foobar, 'Incorrect tokens')
     expected_message = 'Token error: Incorrect tokens'
 
 
 class AuthMissingParameterTest(BaseExceptionTestCase):
-    exception = AuthMissingParameter('foobar', 'username')
+    exception = AuthMissingParameter(foobar, 'username')
     expected_message = 'Missing needed parameter username'
 
 
 class AuthStateMissingTest(BaseExceptionTestCase):
-    exception = AuthStateMissing('foobar')
+    exception = AuthStateMissing(foobar)
     expected_message = 'Session value state missing.'
 
 
@@ -58,31 +65,31 @@ class NotAllowedToDisconnectTest(BaseExceptionTestCase):
 
 
 class AuthExceptionTest(BaseExceptionTestCase):
-    exception = AuthException('foobar', 'message')
+    exception = AuthException(foobar, 'message')
     expected_message = 'message'
 
 
 class AuthCanceledTest(BaseExceptionTestCase):
-    exception = AuthCanceled('foobar')
+    exception = AuthCanceled(foobar)
     expected_message = 'Authentication process canceled'
 
 
 class AuthUnknownErrorTest(BaseExceptionTestCase):
-    exception = AuthUnknownError('foobar', 'some error')
+    exception = AuthUnknownError(foobar, 'some error')
     expected_message = 'An unknown error happened while ' \
                        'authenticating some error'
 
 
 class AuthStateForbiddenTest(BaseExceptionTestCase):
-    exception = AuthStateForbidden('foobar')
+    exception = AuthStateForbidden(foobar)
     expected_message = 'Wrong state parameter given.'
 
 
 class AuthAlreadyAssociatedTest(BaseExceptionTestCase):
-    exception = AuthAlreadyAssociated('foobar')
+    exception = AuthAlreadyAssociated(foobar)
     expected_message = ''
 
 
 class AuthTokenRevokedTest(BaseExceptionTestCase):
-    exception = AuthTokenRevoked('foobar')
+    exception = AuthTokenRevoked(foobar)
     expected_message = 'User revoke access to the token'


### PR DESCRIPTION
I want to propose/discuss a possibility to add an i18n support for `python-social-auth`

Here's my patch with some notes

I just want to be sure, that I'm moving in right direction and there's a possibility for merge it with base project.
## What I did:

I discovered a `Strategy` class and subclasses for each web framework, and decided to put internationalization stuff in this class. And these strategies are injected everywhere in library core

In base class I created a method `ugettext`, which, by default, just return a string, that was passed as only argument

In `Django` subclass (I have no much experience with other supported frameworks) I overrode it with Django's own `ugettext` function

I wrapped each message (all messages, that I could find) with `backend.strategy.ugettext` (or similar), so they are translated

For default django app I manually created `django.po` file with translations for Russian language

Other frameworks should provide their `ugettext` implementation and translation resources

And it all works as expected
