### PR TITLE
Let Django resolve URL when getting from settings

### DIFF
--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import authenticate
-from django.shortcuts import redirect
+from django.shortcuts import redirect, resolve_url
 from django.template import TemplateDoesNotExist, RequestContext, loader
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
@@ -35,6 +35,8 @@ class DjangoStrategy(BaseStrategy):
         # Force text on URL named settings that are instance of Promise
         if name.endswith('_URL') and isinstance(value, Promise):
             value = force_text(value)
+        if name.endswith('_URL'):
+            return resolve_url(value)
         return value
 
     def request_data(self, merge=True):


### PR DESCRIPTION
Fixes #831.

Should hopefully do nothing for existing URLs and resolves other named URLs.
