### PR TITLE
Corrected default value of JSONField

### DIFF
--- a/social/apps/django_app/default/fields.py
+++ b/social/apps/django_app/default/fields.py
@@ -17,7 +17,7 @@ class JSONField(models.TextField):
     """
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', '{}')
+        kwargs.setdefault('default', {})
         super(JSONField, self).__init__(*args, **kwargs)
 
     def from_db_value(self, value, expression, connection, context):

--- a/social/apps/django_app/default/migrations/0004_auto_20160423_0400.py
+++ b/social/apps/django_app/default/migrations/0004_auto_20160423_0400.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import social.apps.django_app.default.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default', '0003_alter_email_max_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='usersocialauth',
+            name='extra_data',
+            field=social.apps.django_app.default.fields.JSONField(default={}),
+        ),
+    ]


### PR DESCRIPTION
The default should be an empty dict, not a string value.

Fixes #898