### PR TITLE
Updates to OpenIdConnectAuth

### DIFF
--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -325,13 +325,19 @@ class OpenIdConnectAuth(BaseOAuth2):
         http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation.
         """
         client_id, _client_secret = self.get_key_and_secret()
-        decryption_key = self.setting('ID_TOKEN_DECRYPTION_KEY')
+
+        decode_kwargs = {
+            'algorithms': ['HS256'],
+            'audience': client_id,
+            'issuer': self.ID_TOKEN_ISSUER,
+            'key': self.setting('ID_TOKEN_DECRYPTION_KEY'),
+        }
+        decode_kwargs.update(self.setting('ID_TOKEN_JWT_DECODE_KWARGS', {}))
+
         try:
             # Decode the JWT and raise an error if the secret is invalid or
             # the response has expired.
-            id_token = jwt_decode(id_token, decryption_key, audience=client_id,
-                                  issuer=self.ID_TOKEN_ISSUER,
-                                  algorithms=['HS256'])
+            id_token = jwt_decode(id_token, **decode_kwargs)
         except InvalidTokenError as err:
             raise AuthTokenError(self, err)
 

--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -2,18 +2,16 @@ import datetime
 from calendar import timegm
 
 from jwt import InvalidTokenError, decode as jwt_decode
-
 from openid.consumer.consumer import Consumer, SUCCESS, CANCEL, FAILURE
 from openid.consumer.discover import DiscoveryFailure
 from openid.extensions import sreg, ax, pape
 
-from social.utils import url_add_parameters
-from social.exceptions import AuthException, AuthFailed, AuthCanceled, \
-                              AuthUnknownError, AuthMissingParameter, \
-                              AuthTokenError
 from social.backends.base import BaseAuth
 from social.backends.oauth import BaseOAuth2
-
+from social.exceptions import (
+    AuthException, AuthFailed, AuthCanceled, AuthUnknownError, AuthMissingParameter, AuthTokenError
+)
+from social.utils import url_add_parameters
 
 # OpenID configuration
 OLD_AX_ATTRS = [
@@ -278,6 +276,7 @@ class OpenIdConnectAuth(BaseOAuth2):
     Currently only the code response type is supported.
     """
     ID_TOKEN_ISSUER = None
+    ID_TOKEN_MAX_AGE = 600
     DEFAULT_SCOPE = ['openid']
     EXTRA_DATA = ['id_token', 'refresh_token', ('sub', 'id')]
     # Set after access_token is retrieved
@@ -331,6 +330,15 @@ class OpenIdConnectAuth(BaseOAuth2):
             'audience': client_id,
             'issuer': self.ID_TOKEN_ISSUER,
             'key': self.setting('ID_TOKEN_DECRYPTION_KEY'),
+            'options': {
+                'verify_signature': True,
+                'verify_exp': True,
+                'verify_iat': True,
+                'verify_aud': True,
+                'verify_iss': True,
+                'require_exp': True,
+                'require_iat': True,
+            },
         }
         decode_kwargs.update(self.setting('ID_TOKEN_JWT_DECODE_KWARGS', {}))
 
@@ -341,9 +349,10 @@ class OpenIdConnectAuth(BaseOAuth2):
         except InvalidTokenError as err:
             raise AuthTokenError(self, err)
 
-        # Verify the token was issued in the last 10 minutes
+        # Verify the token was issued within a specified amount of time
+        iat_leeway = self.setting('ID_TOKEN_MAX_AGE', self.ID_TOKEN_MAX_AGE)
         utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
-        if id_token['iat'] < (utc_timestamp - 600):
+        if id_token['iat'] < (utc_timestamp - iat_leeway):
             raise AuthTokenError(self, 'Incorrect id_token: iat')
 
         # Validate the nonce to ensure the request was not modified


### PR DESCRIPTION
- Added support for passing kwargs to jwt.decode()
- Updated iat claim validation

The first commit adds support for passing kwargs to `jwt.decode()`, allowing for great flexibility to determine, for example, which signing algorithms are used or the expected value of the audience claim.

The second commit (a) instructs PyJWT to verify the iat claim and ensure a value is present, and (b) makes the value against which the claim is compared configurable. I don't know why I hardcoded this to 10 minutes; but, that is not in the spec, and should be configurable for each individual client.