### PR TITLE
Storing token_type in extra_data field when using OAuth 2.0

### DIFF
--- a/social/backends/oauth.py
+++ b/social/backends/oauth.py
@@ -357,6 +357,13 @@ class BaseOAuth2(OAuthAuth):
         return {'Content-Type': 'application/x-www-form-urlencoded',
                 'Accept': 'application/json'}
 
+    def extra_data(self, user, uid, response, details=None, *args, **kwargs):
+        """Return access_token, token_type, and extra defined names to store in
+            extra_data field"""
+        data = super(BaseOAuth2, self).extra_data(user, uid, response, details=details, *args, **kwargs)
+        data['token_type'] = response.get('token_type') or kwargs.get('token_type')
+        return data
+
     def request_access_token(self, *args, **kwargs):
         return self.get_json(*args, **kwargs)
 


### PR DESCRIPTION
This value is useful for authentication servers (AS) that may provide multiple types of tokens. Most servers use the `Bearer` token type; however, we at @edx are transitioning to using `JWT`. The ability to make the switch without having to change our backend would be ideal. Storing the token type means we can avoid hardcoding the value and let the access token response determine which scheme is used for future requests made using the issued token.