### PR TITLE
Add Django AppConfig Label of "social_auth" for migrations

### DIFF
--- a/social/apps/django_app/default/config.py
+++ b/social/apps/django_app/default/config.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class PythonSocialAuthConfig(AppConfig):
     name = 'social.apps.django_app.default'
+    label = 'social_auth'
     verbose_name = 'Python Social Auth'
 
     def ready(self):

--- a/social/apps/django_app/default/migrations/0002_add_related_name.py
+++ b/social/apps/django_app/default/migrations/0002_add_related_name.py
@@ -8,7 +8,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('default', '0001_initial'),
+        ('social_auth', '0001_initial'),
     ]
 
     operations = [

--- a/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
+++ b/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
@@ -11,7 +11,7 @@ EMAIL_LENGTH = getattr(settings, setting_name('EMAIL_LENGTH'), 254)
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('default', '0002_add_related_name'),
+        ('social_auth', '0002_add_related_name'),
     ]
 
     operations = [


### PR DESCRIPTION
now displays social_auth instead of 'default' when running migration tool