### PR TITLE
Allow AbstractUserSocialAuth to be subclassed without name clashes

### DIFF
--- a/social/apps/django_app/me/models.py
+++ b/social/apps/django_app/me/models.py
@@ -32,7 +32,7 @@ def _get_user_model():
 
     try:
         # Custom user model support with MongoEngine 0.8
-        from mongoengine.django.mongo_auth.models import get_user_document
+        from django_mongoengine.mongo_auth.managers import get_user_document
         return get_user_document()
     except ImportError:
         return module_member('mongoengine.django.auth.User')


### PR DESCRIPTION
This change is not backwards compatible, but as of now it's impossible to subclass AbstractUserSocialAuth