### PR TITLE
django migration should respect SOCIAL_AUTH_USER_MODEL setting

### DIFF
--- a/social/apps/django_app/default/migrations/0002_add_related_name.py
+++ b/social/apps/django_app/default/migrations/0002_add_related_name.py
@@ -4,6 +4,12 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 from django.conf import settings
 
+from social.utils import setting_name
+
+USER_MODEL = getattr(settings, setting_name('USER_MODEL'), None) or \
+             getattr(settings, 'AUTH_USER_MODEL', None) or \
+             'auth.User'
+
 
 class Migration(migrations.Migration):
 
@@ -15,6 +21,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='usersocialauth',
             name='user',
-            field=models.ForeignKey(related_name='social_auth', to=settings.AUTH_USER_MODEL)
+            field=models.ForeignKey(related_name='social_auth', to=USER_MODEL)
         ),
     ]


### PR DESCRIPTION
We use stock `auth.User` model for administrators (without social auth) and custom `UserAccount` model for other types of users with enabled social auth. So we have `SOCIAL_AUTH_USER_MODEL = 'customauth.UserAccount'`.

The patch fixes the following failure:

```
./manage.py migrate --fake-initial

django.db.utils.IntegrityError: insert or update on table "social_auth_usersocialauth" violates foreign key constraint "social_auth_usersocialauth_user_id_17d28448_fk_auth_user_id"
DETAIL:  Key (user_id)=(225873) is not present in table "auth_user".
```