### PR TITLE
Avoid passing bytes to string format in header

### DIFF
--- a/social/backends/reddit.py
+++ b/social/backends/reddit.py
@@ -44,7 +44,7 @@ class RedditOAuth2(BaseOAuth2):
         return {
             'Authorization': 'Basic {0}'.format(base64.urlsafe_b64encode(
                 ('{0}:{1}'.format(*self.get_key_and_secret()).encode())
-            ))
+            ).decode())
         }
 
     def refresh_token_params(self, token, redirect_uri=None, *args, **kwargs):


### PR DESCRIPTION
Using Python 3, we need to pass a str to format, not bytes. Otherwise we end up with an Authorization that looks like:

Authorization: Basic b'Zm9vOmJhcg=='