### PR TITLE
Switch from flask.ext.login to flask_login

### DIFF
--- a/examples/flask_example/__init__.py
+++ b/examples/flask_example/__init__.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from flask import Flask, g
-from flask.ext import login
+from flask_login import LoginManager, current_user
 
 sys.path.append('../..')
 
@@ -29,7 +29,7 @@ db_session = scoped_session(Session)
 app.register_blueprint(social_auth)
 init_social(app, db_session)
 
-login_manager = login.LoginManager()
+login_manager = LoginManager()
 login_manager.login_view = 'main'
 login_manager.login_message = ''
 login_manager.init_app(app)
@@ -48,7 +48,7 @@ def load_user(userid):
 
 @app.before_request
 def global_user():
-    g.user = login.current_user
+    g.user = current_user
 
 
 @app.teardown_appcontext

--- a/examples/flask_example/models/user.py
+++ b/examples/flask_example/models/user.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, String, Integer, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 
-from flask.ext.login import UserMixin
+from flask_login import UserMixin
 
 from flask_example import db_session
 

--- a/examples/flask_example/routes/main.py
+++ b/examples/flask_example/routes/main.py
@@ -1,5 +1,5 @@
 from flask import render_template, redirect
-from flask.ext.login import login_required, logout_user
+from flask_login import login_required, logout_user
 
 from flask_example import app
 

--- a/examples/flask_me_example/__init__.py
+++ b/examples/flask_me_example/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 from flask import Flask, g
-from flask.ext import login
+from flask_login import LoginManager, current_user
 from flask.ext.mongoengine import MongoEngine
 
 sys.path.append('../..')
@@ -26,7 +26,7 @@ db = MongoEngine(app)
 app.register_blueprint(social_auth)
 init_social(app, db)
 
-login_manager = login.LoginManager()
+login_manager = LoginManager()
 login_manager.login_view = 'main'
 login_manager.login_message = ''
 login_manager.init_app(app)
@@ -45,7 +45,7 @@ def load_user(userid):
 
 @app.before_request
 def global_user():
-    g.user = login.current_user
+    g.user = current_user
 
 
 @app.context_processor

--- a/examples/flask_me_example/models/user.py
+++ b/examples/flask_me_example/models/user.py
@@ -1,6 +1,6 @@
 from mongoengine import StringField, EmailField, BooleanField
 
-from flask.ext.login import UserMixin
+from flask_login import UserMixin
 
 from flask_me_example import db
 

--- a/examples/flask_me_example/routes/main.py
+++ b/examples/flask_me_example/routes/main.py
@@ -1,5 +1,5 @@
 from flask import render_template, redirect
-from flask.ext.login import login_required, logout_user
+from flask_login import login_required, logout_user
 
 from flask_me_example import app
 

--- a/social/apps/flask_app/routes.py
+++ b/social/apps/flask_app/routes.py
@@ -1,5 +1,5 @@
 from flask import g, Blueprint, request
-from flask.ext.login import login_required, login_user
+from flask_login import login_required, login_user
 
 from social.actions import do_auth, do_complete, do_disconnect
 from social.apps.flask_app.utils import psa


### PR DESCRIPTION
Importing flask.ext.login is deprecated, use flask_login instead.

See pallets/flask#1135 for details.