### PR TITLE
Add redirect_uri to yammer docs

### DIFF
--- a/docs/backends/yammer.rst
+++ b/docs/backends/yammer.rst
@@ -10,7 +10,8 @@ Production Mode
 In order to enable the backend, follow:
 
 
-- Register an application at `Client Applications`_
+- Register an application at `Client Applications`_,
+  set the ``Redirect URI`` to ``http://<your hostname>/complete/yammer/``
 
 - Fill **Client Key** and **Client Secret** settings::
 


### PR DESCRIPTION
In 2015, Yammer revised their security requirements to require the exact redirect_uri, rather than just the domain.  As a result, it is important that python-social-auth specify the appropriate redirect_uri in the documentation.

The documentation format in this PR matches the format of other backends, such as [foursquare](https://github.com/omab/python-social-auth/blob/master/docs/backends/foursquare.rst)

[yammer documentation](https://developer.yammer.com/blog/action-required-please-make-this-simple-update-prior-to-august-25-2015)