### PR TITLE
Fixed Django Migrations

### DIFF
--- a/social/apps/django_app/default/migrations/0001_initial.py
+++ b/social/apps/django_app/default/migrations/0001_initial.py
@@ -23,6 +23,8 @@ ASSOCIATION_HANDLE_LENGTH = getattr(
 
 
 class Migration(migrations.Migration):
+    replaces = [('default', '0001_initial')]
+
     dependencies = [
         migrations.swappable_dependency(USER_MODEL),
     ]

--- a/social/apps/django_app/default/migrations/0002_add_related_name.py
+++ b/social/apps/django_app/default/migrations/0002_add_related_name.py
@@ -12,6 +12,7 @@ USER_MODEL = getattr(settings, setting_name('USER_MODEL'), None) or \
 
 
 class Migration(migrations.Migration):
+    replaces = [('default', '0002_add_related_name')]
 
     dependencies = [
         ('social_auth', '0001_initial'),

--- a/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
+++ b/social/apps/django_app/default/migrations/0003_alter_email_max_length.py
@@ -10,6 +10,8 @@ EMAIL_LENGTH = getattr(settings, setting_name('EMAIL_LENGTH'), 254)
 
 
 class Migration(migrations.Migration):
+    replaces = [('default', '0003_alter_email_max_length')]
+
     dependencies = [
         ('social_auth', '0002_add_related_name'),
     ]

--- a/social/apps/django_app/default/migrations/0004_auto_20160423_0400.py
+++ b/social/apps/django_app/default/migrations/0004_auto_20160423_0400.py
@@ -6,6 +6,7 @@ import social.apps.django_app.default.fields
 
 
 class Migration(migrations.Migration):
+    replaces = [('default', '0004_auto_20160423_0400')]
 
     dependencies = [
         ('social_auth', '0003_alter_email_max_length'),


### PR DESCRIPTION
The app rename in #916 breaks migrations for previously-setup systems. This commit informs Django that the migrations under the new app name replace the migrations under the old app name.

Fixes #991