### PR TITLE
Preserve order of backends in BACKENDSCACHE

### DIFF
--- a/social/backends/utils.py
+++ b/social/backends/utils.py
@@ -1,10 +1,12 @@
+from collections import OrderedDict
+
 from social.exceptions import MissingBackend
 from social.backends.base import BaseAuth
 from social.utils import module_member, user_is_authenticated
 
 
 # Cache for discovered backends.
-BACKENDSCACHE = {}
+BACKENDSCACHE = OrderedDict()
 
 
 def load_backends(backends, force_load=False):
@@ -27,7 +29,7 @@ def load_backends(backends, force_load=False):
     """
     global BACKENDSCACHE
     if force_load:
-        BACKENDSCACHE = {}
+        BACKENDSCACHE = OrderedDict()
     if not BACKENDSCACHE:
         for auth_backend in backends:
             backend = module_member(auth_backend)

--- a/social/tests/backends/test_utils.py
+++ b/social/tests/backends/test_utils.py
@@ -23,8 +23,7 @@ class LoadBackendsTest(BaseBackendUtilsTest):
             'social.backends.flickr.FlickrOAuth'
         ), force_load=True)
         keys = list(loaded_backends.keys())
-        keys.sort()
-        self.assertEqual(keys, ['facebook', 'flickr', 'github'])
+        self.assertEqual(keys, ['github', 'facebook', 'flickr'])
 
         backends = ()
         loaded_backends = load_backends(backends, force_load=True)


### PR DESCRIPTION
When I load backends with `load_backends`, it returns `BACKENDSCACHE`, which is unordered `dict`.
It's very unhandy to order result later, so it would be nice, if `BACKENDSCACHE` kept order of backends passed as argument
