### PR TITLE
[Moves][Fix] Convert username to string

### DIFF
--- a/social/backends/moves.py
+++ b/social/backends/moves.py
@@ -22,7 +22,7 @@ class MovesOAuth2(BaseOAuth2):
 
     def get_user_details(self, response):
         """Return user details Moves account"""
-        return {'username': response.get('user_id')}
+        return {'username': str(response.get('user_id'))}
 
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""


### PR DESCRIPTION
Hi all,

I got error in line
https://github.com/omab/python-social-auth/blob/master/social/pipeline/user.py#L45

In this line, we split username value into parts. But if a username is an int value, then we will get an error.
In Moves backend, we store user_id (int value) in a username variable.

https://github.com/omab/python-social-auth/blob/master/social/backends/moves.py#L25
