### PR TITLE
Add setting to fine-tune admin search fields

### DIFF
--- a/social/apps/django_app/default/admin.py
+++ b/social/apps/django_app/default/admin.py
@@ -29,7 +29,8 @@ class UserSocialAuthOption(admin.ModelAdmin):
             all_names = self._get_all_field_names(_User._meta)
             search_fields = [name for name in fieldnames
                                 if name and name in all_names]
-        return ['user__' + name for name in search_fields]
+        return ['user__' + name for name in search_fields] + \
+            getattr(settings, setting_name('ADMIN_SEARCH_FIELDS'), [])
 
     @staticmethod
     def _get_all_field_names(model):


### PR DESCRIPTION
One day i needed to configure search fields of _UserSocialAuth_ like this:

>  search_fields = ['=user__id', '^user__email', '=uid']

I found the setting _ADMIN_USER_SEARCH_FIELDS_, but it was very limited. It does not allow to do restrictive searches, using by [prefix the field name with an operator](https://docs.djangoproject.com/en/1.10/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields).

Also, since the setting has related to User model, you can't search by the other models fields.

I've added new setting **ADMIN_SEARCH_FIELDS**. Please, review!
