### PR TITLE
added get_next_param()

### DIFF
--- a/social/strategies/django_strategy.py
+++ b/social/strategies/django_strategy.py
@@ -44,10 +44,23 @@ class DjangoStrategy(BaseStrategy):
             data = self.request.GET.copy()
             data.update(self.request.POST)
         elif self.request.method == 'POST':
-            data = self.request.POST
+            data = self.request.POST.copy()
+            next_param = self.get_next_param()
+            if next_param:
+                data.update({'next': next_param})
         else:
-            data = self.request.GET
+            data = self.request.GET.copy()
+            next_param = self.get_next_param()
+            if next_param:
+                data.update({'next': next_param})
         return data
+
+    def get_next_param(self):
+        next_param = self.request.META.get('HTTP_REFERER', None)
+        if next_param:
+            next_param = next_param.split('?next=')
+            next_param = next_param[1] if len(next_param) > 1 else None
+        return next_param
 
     def request_host(self):
         if self.request:


### PR DESCRIPTION
self.request in DjangoStrategy not contain 'next' redirect url parameter, i found this in self.request.META['HTTP_REFERER']
or i don`t understand where get 'next' :)