### PR TITLE
Fix formatting of SQLAlchemy/Zope note

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -176,8 +176,10 @@ SQLAlchemy and Django mixins
 Currently there are partial implementations of mixins for `SQLAlchemy ORM`_ and
 `Django ORM`_ with common code used later on current implemented applications.
 
-**When using `SQLAlchemy ORM`_ and ``ZopeTransactionExtension``, it's
-recommended to use the transaction_ application to handle them.**
+.. note::
+
+    When using `SQLAlchemy ORM`_ and ``ZopeTransactionExtension``, it's
+    recommended to use the transaction_ application to handle them.
 
 Models Examples
 ---------------


### PR DESCRIPTION
Nesting of inline styles [doesn't currently work](http://docutils.sourceforge.net/FAQ.html#is-nested-inline-markup-possible), so the bold style was replaced with a note directive.
