### PR TITLE
Allow apps to have any type of user_id field.

### DIFF
--- a/social/apps/flask_app/default/models.py
+++ b/social/apps/flask_app/default/models.py
@@ -1,5 +1,5 @@
 """Flask SQLAlchemy ORM models for Social Auth"""
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
@@ -70,7 +70,7 @@ def init_social(app, session):
     _AppSession._set_session(session)
     UserSocialAuth.__table_args__ = (UniqueConstraint('provider', 'uid'),)
     UserSocialAuth.uid = Column(String(UID_LENGTH))
-    UserSocialAuth.user_id = Column(Integer, ForeignKey(User.id),
+    UserSocialAuth.user_id = Column(User.id.type, ForeignKey(User.id),
                                     nullable=False, index=True)
     UserSocialAuth.user = relationship(User, backref=backref('social_auth',
                                                              lazy='dynamic'))

--- a/social/apps/pyramid_app/models.py
+++ b/social/apps/pyramid_app/models.py
@@ -1,5 +1,5 @@
 """Pyramid SQLAlchemy ORM models for Social Auth"""
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.orm import relationship, backref
 
 from social.utils import setting_name, module_member

--- a/social/apps/tornado_app/models.py
+++ b/social/apps/tornado_app/models.py
@@ -1,5 +1,5 @@
 """Tornado SQLAlchemy ORM models for Social Auth"""
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.orm import relationship, backref
 
 from social.utils import setting_name, module_member
@@ -30,7 +30,7 @@ def init_social(Base, session, settings):
     class UserSocialAuth(_AppSession, Base, SQLAlchemyUserMixin):
         """Social Auth association model"""
         uid = Column(String(UID_LENGTH))
-        user_id = Column(Integer, ForeignKey(User.id),
+        user_id = Column(User.id.type, ForeignKey(User.id),
                          nullable=False, index=True)
         user = relationship(User, backref=backref('social_auth',
                                                   lazy='dynamic'))

--- a/social/apps/webpy_app/models.py
+++ b/social/apps/webpy_app/models.py
@@ -1,7 +1,7 @@
 """Flask SQLAlchemy ORM models for Social Auth"""
 import web
 
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, String, ForeignKey
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -28,7 +28,7 @@ class WebpySocialBase(object):
 class UserSocialAuth(WebpySocialBase, SQLAlchemyUserMixin, SocialBase):
     """Social Auth association model"""
     uid = Column(String(UID_LENGTH))
-    user_id = Column(Integer, ForeignKey(User.id),
+    user_id = Column(User.id.type, ForeignKey(User.id),
                      nullable=False, index=True)
     user = relationship(User, backref='social_auth')
 


### PR DESCRIPTION
This is the same as it was done for Pyramid app - do not
expect that User.id will be always an Integer but get it's
type and use it in UserSocialAuth.user_id column.
