### PR TITLE
Remove Facebook2OAuth2 and Facebook2AppOAuth2 backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/omab/python-social-auth/compare/v0.2.21...HEAD)
 
+- Removed Facebook2OAuth2 and Facebook2AppOAuth2 as FacebookAppOAuth2 is now using Graph 2.0
+
 ## [v0.2.21](https://github.com/omab/python-social-auth/tree/v0.2.21) (2016-08-15)
 
 **Closed issues:**

--- a/docs/backends/facebook.rst
+++ b/docs/backends/facebook.rst
@@ -78,14 +78,6 @@ If you need to perform authentication from Facebook Canvas application:
 
 More info on the topic at `Facebook Canvas Application Authentication`_.
 
-
-Graph 2.0
----------
-
-If looking for `Graph 2.0`_ support, use the backends ``Facebook2OAuth2``
-(OAuth2) and/or ``Facebook2AppOAuth2`` (Canvas application).
-
 .. _Facebook development resources: http://developers.facebook.com/docs/authentication/
 .. _Facebook App Creation: http://developers.facebook.com/setup/
 .. _Facebook Canvas Application Authentication: http://www.ikrvss.ru/2011/09/22/django-social-auth-and-facebook-canvas-applications/
-.. _Graph 2.0: https://developers.facebook.com/blog/post/2014/04/30/the-new-facebook-login/

--- a/social/backends/facebook.py
+++ b/social/backends/facebook.py
@@ -196,15 +196,3 @@ class FacebookAppOAuth2(FacebookOAuth2):
             if constant_time_compare(sig, expected_sig) and \
                data['issued_at'] > (time.time() - 86400):
                 return data
-
-
-class Facebook2OAuth2(FacebookOAuth2):
-    """Facebook OAuth2 authentication backend using Facebook Open Graph 2.0"""
-    AUTHORIZATION_URL = 'https://www.facebook.com/v2.0/dialog/oauth'
-    ACCESS_TOKEN_URL = 'https://graph.facebook.com/v2.0/oauth/access_token'
-    REVOKE_TOKEN_URL = 'https://graph.facebook.com/v2.0/{uid}/permissions'
-    USER_DATA_URL = 'https://graph.facebook.com/v2.0/me'
-
-
-class Facebook2AppOAuth2(Facebook2OAuth2, FacebookAppOAuth2):
-    pass


### PR DESCRIPTION
Closes #1045. They are using an endpoint that doesn’t exist anymore,
and the main backends are now more up to date.
