### PR TITLE
Fix init_app db reference to session

### DIFF
--- a/docs/configuration/flask.rst
+++ b/docs/configuration/flask.rst
@@ -31,19 +31,19 @@ Models Setup
 ------------
 
 At the moment the models for python-social-auth_ are defined inside a function
-because they need the reference to the current db instance and the User model
+because they need the reference to the current db session and the User model
 used on your project (check *User model reference* below). Once the Flask app
 and the database are defined, call ``init_social`` to register the models::
 
     from social.apps.flask_app.default.models import init_social
 
-    init_social(app, db)
+    init_social(app, session)
 
 For MongoEngine_::
 
     from social.apps.flask_app.me.models import init_social
 
-    init_social(app, db)
+    init_social(app, session)
 
 So far I wasn't able to find another way to define the models on another way
 rather than making it as a side-effect of calling this function since the


### PR DESCRIPTION
This should say that the init_app function wants the database session and not the actual db reference.

https://github.com/omab/python-social-auth/blob/f13a5cc3c8670a1a3bbc16410bb30ac0423d9934/social/apps/flask_app/default/models.py#L67
