### PR TITLE
Don't lose custom exception message on raising AuthCanceled

### DIFF
--- a/social/exceptions.py
+++ b/social/exceptions.py
@@ -46,6 +46,9 @@ class AuthCanceled(AuthException):
         super(AuthCanceled, self).__init__(*args, **kwargs)
 
     def __str__(self):
+        msg = super(AuthCanceled, self).__str__()
+        if msg:
+            return 'Authentication process canceled: {0}'.format(msg)
         return 'Authentication process canceled'
 
 

--- a/social/tests/test_exceptions.py
+++ b/social/tests/test_exceptions.py
@@ -67,6 +67,11 @@ class AuthCanceledTest(BaseExceptionTestCase):
     expected_message = 'Authentication process canceled'
 
 
+class AuthCanceledWithExtraMessageTest(BaseExceptionTestCase):
+    exception = AuthCanceled('foobar', 'error_message')
+    expected_message = 'Authentication process canceled: error_message'
+
+
 class AuthUnknownErrorTest(BaseExceptionTestCase):
     exception = AuthUnknownError('foobar', 'some error')
     expected_message = 'An unknown error happened while ' \

--- a/social/tests/test_exceptions.py
+++ b/social/tests/test_exceptions.py
@@ -6,7 +6,9 @@ from social.exceptions import SocialAuthBaseException, WrongBackend, \
                               NotAllowedToDisconnect, AuthException, \
                               AuthCanceled, AuthUnknownError, \
                               AuthStateForbidden, AuthAlreadyAssociated, \
-                              AuthTokenRevoked
+                              AuthTokenRevoked, AuthForbidden, \
+                              AuthUnreachableProvider, InvalidEmail, \
+                              MissingBackend
 
 
 class BaseExceptionTestCase(unittest.TestCase):
@@ -91,3 +93,23 @@ class AuthAlreadyAssociatedTest(BaseExceptionTestCase):
 class AuthTokenRevokedTest(BaseExceptionTestCase):
     exception = AuthTokenRevoked('foobar')
     expected_message = 'User revoke access to the token'
+
+
+class AuthForbiddenTest(BaseExceptionTestCase):
+    exception = AuthForbidden('foobar')
+    expected_message = 'Your credentials aren\'t allowed'
+
+
+class AuthUnreachableProviderTest(BaseExceptionTestCase):
+    exception = AuthUnreachableProvider('foobar')
+    expected_message = 'The authentication provider could not be reached'
+
+
+class InvalidEmailTest(BaseExceptionTestCase):
+    exception = InvalidEmail('foobar')
+    expected_message = 'Email couldn\'t be validated'
+
+
+class MissingBackendTest(BaseExceptionTestCase):
+    exception = MissingBackend('backend')
+    expected_message = 'Missing backend "backend" entry'


### PR DESCRIPTION
There are 4 usages of `AuthCanceled` with custom error message. In all those cases the message will be lost without this fix.

- https://github.com/omab/python-social-auth/blob/f13a5cc3c8670a1a3bbc16410bb30ac0423d9934/social/backends/facebook.py#L62-L63
- https://github.com/omab/python-social-auth/blob/f13a5cc3c8670a1a3bbc16410bb30ac0423d9934/social/backends/oauth.py#L171
- https://github.com/omab/python-social-auth/blob/f13a5cc3c8670a1a3bbc16410bb30ac0423d9934/social/backends/oauth.py#L376
- https://github.com/omab/python-social-auth/blob/f13a5cc3c8670a1a3bbc16410bb30ac0423d9934/social/backends/oauth.py#L380