### PR TITLE
Update requirements for django_example

### DIFF
--- a/examples/django_example/requirements.txt
+++ b/examples/django_example/requirements.txt
@@ -1,2 +1,2 @@
-django>=1.4
+django>=1.4,<1.8
 python-social-auth


### PR DESCRIPTION
Fixes https://github.com/omab/python-social-auth/issues/1058

Use django version less than 1.8 to maintain compatibility with `django.conf.urls.patterns`.

