### PR TITLE
fix date in deprecation notice title

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Crafted using base code from django-social-auth, it implements a common interfac
 to define new authentication providers from third parties, and to bring support
 for more frameworks and ORMs.
 
-Deprecation notice - 03-12-2016
+Deprecation notice - 2016-12-03
 -------------------------------
 
 As for Dec 03 2016, this library is now deprecated, the codebase was


### PR DESCRIPTION
Please only use dashes as separator if the date format is ISO 8601 (YYYY-MM-DD)