### PR TITLE
Fixed issue #1102 of omab/python-social-auth

### DIFF
--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -1,2 +1,2 @@
-from social_core.backends.open_id import OpenIdAuth, \
-    OpenIdConnectAssociation, OpenIdConnectAuth
+from social_core.backends.open_id import OpenIdAuth
+from social_core.backends.open_id_connect import OpenIdConnectAssociation, OpenIdConnectAuth


### PR DESCRIPTION
cannot import name 'OpenIdConnectAssociation'

This is an update to the import in social.backends.open_id to reflect OpenIdConnectAssociation and OpenIdConnectAuth moving to social_core.backends.open_id_connect