### PR TITLE
Fixed #1102 cannot import name OpenIdConnectAssociation

### DIFF
--- a/social/backends/open_id.py
+++ b/social/backends/open_id.py
@@ -1,2 +1,2 @@
-from social_core.backends.open_id import OpenIdAuth, \
-    OpenIdConnectAssociation, OpenIdConnectAuth
+from social_core.backends.open_id import OpenIdAuth
+from social_core.backends.open_id_connect import OpenIdConnectAssociation, OpenIdConnectAuth


### PR DESCRIPTION
This is reflect the update to the classes OpenIdConnectAssociation and OpenIdConnectAuth moving to social_core.backends.open_id_connect.